### PR TITLE
Use Roboto over Segoe UI, hide search until typed

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     </header>
 
     <!-- React will be mounted into this DOM node. --->
-    <section id="search" class="hidden">
+    <section id="search" hidden>
     </section>
 
     <section id="join">

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <meta name="description" content="350+ custom emoji for Discord">
   <meta name="theme-color" content="#7289da">
   <title>Blob Emoji</title>
+  <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
   <link rel="stylesheet" href="styles/index.scss">
   <link rel="icon" type="image/png" href="assets/blobs/blobowo.png">
 
@@ -39,7 +40,7 @@
     </header>
 
     <!-- React will be mounted into this DOM node. --->
-    <section id="search" style="display: none;">
+    <section id="search" class="hidden">
     </section>
 
     <section id="join">

--- a/scripts/components/Search.js
+++ b/scripts/components/Search.js
@@ -13,11 +13,17 @@ export default class Search extends React.Component {
 
     this.state = {
       query: '',
+      hasTyped: false,
     }
   }
 
   handleQueryChange = (event) => {
     this.setState({ query: event.currentTarget.value })
+
+    // if the query is not empty, the user has typed at least once
+    // this might be better elsewhere
+    if (event.currentTarget.value !== '')
+      this.setState({ hasTyped: true })
   }
 
   allBlobs() {
@@ -55,13 +61,16 @@ export default class Search extends React.Component {
   }
 
   render() {
-    const { query } = this.state
+    const { query, hasTyped } = this.state
 
     let results
     if (query === '') {
-      results = this.allBlobs()
-        .filter(({ name }) => name.includes('blobs'))
-        .slice(0, 8 * 5)
+      if (hasTyped)
+        results = this.allBlobs()
+          .filter(({ name }) => name.includes('blobs'))
+          .slice(0, 8 * 5)
+      else  // if the user has not typed yet, don't show any results until they do
+        results = []
     } else {
       results = this.filterBlobs()
     }

--- a/styles/_global.scss
+++ b/styles/_global.scss
@@ -20,10 +20,6 @@ section {
   margin: 2rem 0;
 }
 
-.hidden {
-  display: none;
-}
-
 *,
 *:before,
 *:after {

--- a/styles/_global.scss
+++ b/styles/_global.scss
@@ -5,7 +5,7 @@ body {
 
   font-size: 18px;
   line-height: 1.5;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+  font-family: -apple-system, BlinkMacSystemFont, Roboto, 'Segoe UI', Helvetica,
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 
   background-color: $bg;
@@ -18,6 +18,10 @@ h2 {
 
 section {
   margin: 2rem 0;
+}
+
+.hidden {
+  display: none;
 }
 
 *,


### PR DESCRIPTION
This moves Roboto over Segoe UI in the `font-family` declaration, includes the Google Roboto stylesheet to make it available on more systems, and adds a `hasTyped` state to `Search` to stop results from showing on first page load until the user has typed something.

I also added a `hidden` class. Kind of boilerplate, and I mainly added it because I was originally planning to use it for result hiding until I went the state method and felt redundancy in needing `display: none` multiple times. I've kept it in incase it's useful in the future.