### PR TITLE
Add '_metavars.css', fix modal width and allow later adjustment

### DIFF
--- a/scripts/components/Server.js
+++ b/scripts/components/Server.js
@@ -5,7 +5,7 @@ import classnames from 'classnames'
 import Emoji from './Emoji'
 import chevron from '../../assets/chevron-down-solid.svg'
 
-const RANDOM_SAMPLE_SIZE = 5
+const RANDOM_SAMPLE_SIZE = 6
 
 export default class Server extends React.Component {
   constructor(props) {

--- a/styles/_metavars.scss
+++ b/styles/_metavars.scss
@@ -1,4 +1,0 @@
-
-// Variables to do with server modal spacing
-$server-modal-width: 300px;
-$server-modal-count: 3;

--- a/styles/_metavars.scss
+++ b/styles/_metavars.scss
@@ -1,0 +1,4 @@
+
+// Variables to do with server modal spacing
+$server-modal-width: 300px;
+$server-modal-count: 3;

--- a/styles/_mobile.scss
+++ b/styles/_mobile.scss
@@ -1,4 +1,4 @@
-@import 'metavars';
+@import 'vars';
 
 @media (max-width: ($server-modal-width * $server-modal-count) + 150px) {
   main {

--- a/styles/_mobile.scss
+++ b/styles/_mobile.scss
@@ -1,4 +1,6 @@
-@media (max-width: 900px) {
+@import 'metavars';
+
+@media (max-width: ($server-modal-width * $server-modal-count) + 150px) {
   main {
     margin: 0 !important;
     padding: 2rem;

--- a/styles/_servers.scss
+++ b/styles/_servers.scss
@@ -1,4 +1,4 @@
-@import 'metavars';
+@import 'vars';
 
 .join-server {
   display: inline-block;

--- a/styles/_servers.scss
+++ b/styles/_servers.scss
@@ -1,3 +1,5 @@
+@import 'metavars';
+
 .join-server {
   display: inline-block;
   margin-top: 1.5rem;
@@ -53,7 +55,7 @@
 
 .servers {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax($server-modal-width, 1fr));
   grid-gap: 2rem;
   padding: 1rem 0;
 

--- a/styles/_vars.scss
+++ b/styles/_vars.scss
@@ -1,3 +1,9 @@
+
+// Variables to do with server modal spacing
+$server-modal-width: 300px;
+$server-modal-count: 3;
+
+// Color variables
 $blurple: #7289da;
 $white: #fff;
 $bright: #ccc;

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,4 +1,4 @@
-@import 'colors', 'metavars', 'mobile', 'search', 'servers', 'emoji';
+@import 'vars', 'mobile', 'search', 'servers', 'emoji';
 
 html,
 body {

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,4 +1,4 @@
-@import 'colors', 'mobile', 'search', 'servers', 'emoji';
+@import 'colors', 'metavars', 'mobile', 'search', 'servers', 'emoji';
 
 html,
 body {
@@ -41,7 +41,7 @@ section {
 }
 
 main {
-  max-width: 850px;
+  max-width: ($server-modal-width * $server-modal-count) + 100px;
   margin: 1rem auto;
 }
 


### PR DESCRIPTION
This change adds a `_metavars.scss` for storing variables that affect the overall style of the page(s).
In it with this change are the `$server-modal-width` and `$server-modal-count` variables, which adjusts the modal size and scales the page and mobile media hint accordingly.

The current modal width has been changed from `250px` to `300px`, allowing longer names (fixes #10), but if this is insufficient, the aforementioned metavars addition facilitates adjusting this again easily.