### PR TITLE
Represent internal structures with neater classes

### DIFF
--- a/scripts/components/Emoji.js
+++ b/scripts/components/Emoji.js
@@ -10,12 +10,16 @@ export default function Emoji({
   id,
   animated,
   name,
-  server,
+  guild,
   baseSize = 64,
   ...rest
 }) {
   const extension = animated ? 'gif' : 'png'
-  const alt = server ? `:${name}: (${server})` : `:${name}:`
+  let alt = `:${name}:`
+
+  if (guild != null) {
+    alt += ` (${guild.name})`
+  }
 
   const srcSet = `
     ${emojiUrl(id, extension, baseSize)},

--- a/scripts/components/Search.js
+++ b/scripts/components/Search.js
@@ -2,15 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import debounce from 'lodash.debounce'
 
-import { log } from '../utils'
 import Emoji from './Emoji'
 import { Servers } from './Servers'
 import SearchResult from './SearchResult'
-import { fromEntries } from '../utils'
+
+function insensitiveIncludes(haystack, needle) {
+  return haystack.toLowerCase().includes(needle.toLowerCase())
+}
 
 export default class Search extends React.Component {
   static propTypes = {
-    data: PropTypes.object.isRequired,
+    emojis: PropTypes.object.isRequired,
   }
 
   constructor(props) {
@@ -18,38 +20,24 @@ export default class Search extends React.Component {
 
     this.state = {
       query: '',
-
       isDebouncing: false,
-      blobs: [],
-      servers: {},
+      filteredBlobs: [],
+      filteredGuilds: {},
     }
 
-    this.allGuilds = Object.assign({}, ...Object.values(props.data))
-
-    // Inject `invite` and `server` properties to all emoji objects.
-    // TODO: Unify the invite and server properties into one property.
-    //       We need the ID, too!
-    this.allBlobs = Object.values(this.allGuilds).reduce(
-      (acc, guild) => [
-        ...guild.emoji.map((emoji) => ({
-          ...emoji,
-          invite: guild.invite,
-          server: guild.name,
-        })),
-        ...acc,
-      ],
-      []
-    )
+    // Calculate these values once, as they are fairly large.
+    this.allEmoji = this.props.emojis.getAllEmoji()
+    this.allGuilds = this.props.emojis.getAllGuilds()
 
     this.calculateResultsDebounced = debounce(this.calculateResults, 150)
   }
 
   getSadBlob() {
-    // TODO: Use the server ID once that's injected into emoji objects.
-    const blob = this.allBlobs.find(
-      ({ server, name }) => server === 'Blob Emoji' && name === 'blobsad'
+    const sadBlob = this.allEmoji.find(
+      (emoji) =>
+        emoji.guild.id === '272885620769161216' && emoji.name === 'blobsad'
     )
-    return blob == null ? null : <Emoji {...blob} />
+    return sadBlob == null ? null : <Emoji {...sadBlob} />
   }
 
   handleQueryChange = (event) => {
@@ -70,41 +58,37 @@ export default class Search extends React.Component {
   calculateResults() {
     this.setState(({ query }) => {
       if (query === '') {
-        return { blobs: [], servers: {}, isDebouncing: false }
+        return { filteredBlobs: [], filteredGuilds: {}, isDebouncing: false }
       }
 
       return {
-        blobs: this.filterBlobs(query),
-        servers: this.filterServers(query),
+        filteredBlobs: this.filterBlobs(query),
+        filteredGuilds: this.filterGuilds(query),
         isDebouncing: false,
       }
     })
   }
 
   filterBlobs(query) {
-    return this.allBlobs
-      .filter((blob) => blob.name.includes(query.toLowerCase()))
+    return this.allEmoji
+      .filter((blob) => insensitiveIncludes(blob.name, query))
       .sort(({ name: a }, { name: b }) => a.length - b.length)
       .slice(0, 8 * 5)
   }
 
-  filterServers(query) {
-    return fromEntries(
-      Object.entries(this.allGuilds)
-        .filter(([id, guild]) =>
-          guild.name.toLowerCase().includes(query.toLowerCase())
-        )
-        .slice(0, 3)
-    )
+  filterGuilds(query) {
+    return this.allGuilds
+      .filter((guild) => insensitiveIncludes(guild.name, query))
+      .slice(0, 3)
   }
 
   render() {
-    const { query, blobs, servers, isDebouncing } = this.state
+    const { query, filteredBlobs, filteredGuilds, isDebouncing } = this.state
 
     const hasResults =
-      blobs != null &&
-      servers != null &&
-      (blobs.length !== 0 || Object.keys(servers).length !== 0)
+      filteredBlobs != null &&
+      filteredGuilds != null &&
+      (filteredBlobs.length !== 0 || Object.keys(filteredGuilds).length !== 0)
     const hideNoResults = query.length === 0 || isDebouncing
 
     return (
@@ -124,10 +108,10 @@ export default class Search extends React.Component {
           ) : (
             <>
               <div id="search-results-servers">
-                <Servers servers={servers} />
+                <Servers servers={filteredGuilds} />
               </div>
               <div id="search-results-blobs">
-                {blobs.map((blob) => (
+                {filteredBlobs.map((blob) => (
                   <SearchResult key={blob.id} blob={blob} />
                 ))}
               </div>

--- a/scripts/components/Server.js
+++ b/scripts/components/Server.js
@@ -26,13 +26,11 @@ export default class Server extends React.Component {
   }
 
   get empty() {
-    const { server } = this.props
-    return server.emoji.length === 0
+    return this.props.server.emoji.length === 0
   }
 
   get expandable() {
-    const { server } = this.props
-    return server.emoji.length > RANDOM_SAMPLE_SIZE
+    return this.props.server.emoji.length > RANDOM_SAMPLE_SIZE
   }
 
   handleClick = () => {

--- a/scripts/components/Servers.js
+++ b/scripts/components/Servers.js
@@ -7,13 +7,13 @@ import { shuffleArray } from '../utils'
 const SERVERS_PER_PAGE = 6
 
 export function Servers({ servers, ...props }) {
-  return Object.entries(servers).map(([id, server]) => (
-    <Server key={id} server={{ id, ...server }} {...props} />
+  return servers.map((server) => (
+    <Server key={server.id} server={server} {...props} />
   ))
 }
 
 Servers.propTypes = {
-  servers: PropTypes.object.isRequired,
+  servers: PropTypes.array.isRequired,
 }
 
 export function CommunityServers(props) {
@@ -46,4 +46,8 @@ export function CommunityServers(props) {
       )}
     </>
   )
+}
+
+CommunityServers.propTypes = {
+  servers: PropTypes.array.isRequired,
 }

--- a/scripts/emojis.js
+++ b/scripts/emojis.js
@@ -1,0 +1,53 @@
+/* eslint-disable max-classes-per-file */
+
+export class Emoji {
+  constructor(guild, data) {
+    this.guild = guild
+    Object.assign(this, data)
+  }
+}
+
+export class Guild {
+  constructor(id, guild) {
+    this.id = id
+    this.name = guild.name
+    this.invite = guild.invite
+    this.icon = guild.icon
+
+    this.emoji = guild.emoji.map((emoji) => new Emoji(this, emoji))
+  }
+}
+
+export class EmojiGroup {
+  constructor(guildMapping) {
+    this.guilds = Object.entries(guildMapping).map(
+      ([guildId, guild]) => new Guild(guildId, guild)
+    )
+  }
+}
+
+export class Emojis {
+  constructor(data) {
+    this.groups = {}
+
+    for (const [groupName, guildMapping] of Object.entries(data)) {
+      this.groups[groupName] = new EmojiGroup(guildMapping)
+    }
+  }
+
+  /**
+   * Returns all guilds across all groups.
+   * @return {Guild[]} All guilds.
+   */
+  getAllGuilds() {
+    return [...Object.values(this.groups).flatMap((group) => group.guilds)]
+  }
+
+  /**
+   * Returns all emoji across all guilds across all groups.
+   * @return {Emoji[]} All emoji.
+   */
+  getAllEmoji() {
+    return this.getAllGuilds().flatMap((guild) => guild.emoji)
+  }
+}

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 
 import { log } from './utils'
+import { Emojis } from './emojis'
 import Search from './components/Search'
 import { CommunityServers, Servers } from './components/Servers'
 
@@ -32,17 +33,23 @@ function updatePageState(data) {
 }
 
 function mount(data) {
+  const emojis = new Emojis(data)
+
+  log('Emojis:', emojis)
+
   log('Mounting search...')
   const searchNode = document.querySelector('#search')
   searchNode.removeAttribute('hidden')
-  ReactDOM.render(<Search data={data} />, searchNode)
+  ReactDOM.render(<Search emojis={emojis} />, searchNode)
 
   log('Mounting servers...')
   const servers = document.querySelector('.servers')
   const communityServers = document.querySelector('.community-servers-wrapper')
-  const { blobs, 'community-blobs': community } = data
-  ReactDOM.render(<Servers servers={blobs} />, servers)
-  ReactDOM.render(<CommunityServers servers={community} />, communityServers)
+  ReactDOM.render(<Servers servers={emojis.groups.blobs.guilds} />, servers)
+  ReactDOM.render(
+    <CommunityServers servers={emojis.groups['community-blobs'].guilds} />,
+    communityServers
+  )
 }
 
 if (typeof window.fetch !== 'undefined') {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -28,10 +28,3 @@ export function shuffleArray(source) {
 
   return array
 }
-
-/**
- * Converts an array as returned from Object.entries back into an object.
- */
-export function fromEntries(entries) {
-  return entries.reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {})
-}


### PR DESCRIPTION
Instead of keeping everything as plain objects and arrays, let's wrap them all in classes that make the huge tree of data more organized. This will make it easier to implement fine-grained filtering in the future without clutter.

Also, multiple internal instances of "server" were replaced with "guild" to be consistent with how the Discord API works. I might extend this naming scheme to the rest of the codebase in the future.