### PR TITLE
12/24 Hour Format Toggle, Settings Overhaul and other sorts of goodies

### DIFF
--- a/scripts/App.js
+++ b/scripts/App.js
@@ -170,7 +170,7 @@ function App() {
     breakpoints: {
       values: {
         xs: 0,
-        sm: 600,
+        sm: 750,
         md: 1100,
         lg: 1280,
         xl: 1920

--- a/scripts/App.js
+++ b/scripts/App.js
@@ -4,7 +4,7 @@ import ThemeProvider from '@material-ui/styles/ThemeProvider'
 import createMuiTheme from '@material-ui/core/styles/createMuiTheme'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import Homepage from './pages/homepage'
-import { calculateEmojiCount, log, storageAvailable, warn } from './utils'
+import { calculateEmojiCount, log, storageAvailable, warn, getHourFormat } from './utils'
 import { Emojis } from './emojis'
 import Changepage from './pages/changepage'
 import Header from './components/Header'
@@ -34,6 +34,14 @@ function storageHandler() {
       } else {
         log('Using theme in local storage')
         prefersDarkMode = localStorageTheme === 'true'
+      }
+      const localStorageHourFormat = localStorage.getItem('hourFormat')
+      if (localStorageHourFormat === null) {
+        log('No hour format detected. Using automatic')
+        localStorage.setItem('hourFormat', getHourFormat())
+        localStorage.setItem('automatic', 'true')
+      } else {
+        log('Using hour format in local storage')
       }
     } else {
       log('Is automated. Using user preference')

--- a/scripts/App.js
+++ b/scripts/App.js
@@ -177,6 +177,7 @@ function App() {
           open={settingsOpen}
           onClose={toggleSettingsOpen}
           handleReload={handleReload}
+          setIsTime12={setIsTime12}
         />
       </Router>
     </ThemeProvider>

--- a/scripts/App.js
+++ b/scripts/App.js
@@ -4,7 +4,7 @@ import ThemeProvider from '@material-ui/styles/ThemeProvider'
 import createMuiTheme from '@material-ui/core/styles/createMuiTheme'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import Homepage from './pages/homepage'
-import { calculateEmojiCount, log, storageAvailable, warn, getHourFormat } from './utils'
+import { calculateEmojiCount, log, storageAvailable, warn, getDefaultHourFormat } from './utils'
 import { Emojis } from './emojis'
 import Changepage from './pages/changepage'
 import Header from './components/Header'
@@ -38,7 +38,7 @@ function storageHandler() {
       const localStorageHourFormat = localStorage.getItem('hourFormat')
       if (localStorageHourFormat === null) {
         log('No hour format detected. Using automatic')
-        localStorage.setItem('hourFormat', getHourFormat())
+        localStorage.setItem('hourFormat', getDefaultHourFormat())
         localStorage.setItem('automatic', 'true')
       } else {
         log('Using hour format in local storage')

--- a/scripts/App.js
+++ b/scripts/App.js
@@ -169,7 +169,11 @@ function App() {
     },
     breakpoints: {
       values: {
+        xs: 0,
+        sm: 600,
         md: 1100,
+        lg: 1280,
+        xl: 1920
       },
     },
   }), [prefersDarkMode])

--- a/scripts/App.js
+++ b/scripts/App.js
@@ -22,7 +22,7 @@ function getConfig() {
   })
   const defaultHoursFormat = getDefaultHourFormat()
   const [resPDM, resPDMLS] = getKeyWrapper('darkTheme', prefersDarkMode)
-  const [resHF, resHFLS] = getKeyWrapper('hourFormat', defaultHoursFormat)
+  const [resHF, resHFLS] = getKeyWrapper('prefers12Hour', defaultHoursFormat)
   return { prefersDarkMode: resPDM, prefersHour12: resHF }
 }
 
@@ -44,15 +44,6 @@ function App() {
   const [settingsOpen, toggleSettingsOpen] = useState(false)
   const [, handleReload] = useState(0)
   const { prefersDarkMode } = getConfig()
-  const [isTime12, setIsTime12] = React.useState(null)
-
-  useEffect(() => {
-    if (isTime12 === null) {
-      const defaultHoursFormat = getDefaultHourFormat()
-      const [resIsTime12, isTime12LS] = getKeyWrapper('prefers12Hour', defaultHoursFormat)
-      setIsTime12(resIsTime12)
-    }
-  }, [isTime12])
 
   useEffect(() => {
     if (formattedCount === '0') {
@@ -168,7 +159,7 @@ function App() {
           <Header handleOpen={toggleSettingsOpen} />
         </Container>
         <Switch>
-          <Route path="/changes" children={<Changepage isTime12={isTime12}/>} />
+          <Route path="/changes" children={<Changepage />} />
           <Route
             exact-path="/"
             children={<Homepage formattedCount={formattedCount} emojis={emojis} />} />
@@ -177,7 +168,6 @@ function App() {
           open={settingsOpen}
           onClose={toggleSettingsOpen}
           handleReload={handleReload}
-          setIsTime12={setIsTime12}
         />
       </Router>
     </ThemeProvider>

--- a/scripts/components/Avatars.js
+++ b/scripts/components/Avatars.js
@@ -37,22 +37,18 @@ const useStyles = makeStyles({
   delete: {
     color: red[500],
     verticalAlign: 'middle',
-    margin: '0.5rem',
   },
   create: {
     color: green[500],
     verticalAlign: 'middle',
-    margin: '0.5rem',
   },
   rename: {
     color: lightBlue[500],
     verticalAlign: 'middle',
-    margin: '0.5rem',
   },
   update: {
     color: indigo[400],
     verticalAlign: 'middle',
-    margin: '0.5rem',
   },
 })
 

--- a/scripts/components/RecentChanges/ChangeRow.js
+++ b/scripts/components/RecentChanges/ChangeRow.js
@@ -22,21 +22,22 @@ const useStyles = makeStyles({
   },
 })
 
-export default function ChangeRow({
+function ChangeRow({
   eventIcon,
   eventName,
   emoji,
   action,
   afterEmoji,
   changedAt,
+  isTime12
 }) {
   const classes = useStyles()
-  
+
   return (
     <Box display="flex" alignItems="center">
       <Box display="flex" alignItems="center" minWidth="7.1rem">
         <Box margin="0.5rem">
-          <Tooltip title={getDateTimeFormatter().format(new Date(changedAt))} arrow>
+          <Tooltip title={getDateTimeFormatter(isTime12).format(new Date(changedAt))} arrow>
             <div>{eventIcon}</div>
           </Tooltip>
         </Box>
@@ -66,4 +67,7 @@ ChangeRow.propTypes = {
   action: PropTypes.string.isRequired,
   afterEmoji: PropTypes.object,
   changedAt: PropTypes.string.isRequired,
+  isTime12: PropTypes.bool.isRequired
 }
+
+export default ChangeRow

--- a/scripts/components/RecentChanges/ChangeRow.js
+++ b/scripts/components/RecentChanges/ChangeRow.js
@@ -29,7 +29,6 @@ function ChangeRow({
   action,
   afterEmoji,
   changedAt,
-  isTime12
 }) {
   const classes = useStyles()
 
@@ -37,7 +36,7 @@ function ChangeRow({
     <Box display="flex" alignItems="center">
       <Box display="flex" alignItems="center" minWidth="7.1rem">
         <Box margin="0.5rem">
-          <Tooltip title={getDateTimeFormatter(isTime12).format(new Date(changedAt))} arrow>
+          <Tooltip title={getDateTimeFormatter().format(new Date(changedAt))} arrow>
             <div>{eventIcon}</div>
           </Tooltip>
         </Box>
@@ -67,7 +66,6 @@ ChangeRow.propTypes = {
   action: PropTypes.string.isRequired,
   afterEmoji: PropTypes.object,
   changedAt: PropTypes.string.isRequired,
-  isTime12: PropTypes.bool.isRequired
 }
 
 export default ChangeRow

--- a/scripts/components/RecentChanges/ChangeRow.js
+++ b/scripts/components/RecentChanges/ChangeRow.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { titleCase } from '../../utils'
+import { getDateTimeFormatter, titleCase } from '../../utils'
 import MaterialEmoji from '../material/MaterialEmoji'
 import Box from '@material-ui/core/Box'
 import makeStyles from '@material-ui/core/styles/makeStyles'
 import clsx from 'clsx'
+import Tooltip from '@material-ui/core/Tooltip'
 
 const useStyles = makeStyles({
   changelogBox: {
@@ -27,13 +28,18 @@ export default function ChangeRow({
   emoji,
   action,
   afterEmoji,
+  changedAt,
 }) {
   const classes = useStyles()
   
   return (
     <Box display="flex" alignItems="center">
       <Box display="flex" alignItems="center" minWidth="7.1rem">
-        {eventIcon}
+        <Box margin="0.5rem">
+          <Tooltip title={getDateTimeFormatter().format(new Date(changedAt))} arrow>
+            <div>{eventIcon}</div>
+          </Tooltip>
+        </Box>
         <span>{`${titleCase(eventName)}d`}</span>
       </Box>
       <MaterialEmoji baseSize={32} boxClassName={clsx(classes.changelogBox)} {...emoji} />
@@ -59,4 +65,5 @@ ChangeRow.propTypes = {
   emoji: PropTypes.object.isRequired,
   action: PropTypes.string.isRequired,
   afterEmoji: PropTypes.object,
+  changedAt: PropTypes.string.isRequired,
 }

--- a/scripts/components/RecentChanges/ChangeSet.js
+++ b/scripts/components/RecentChanges/ChangeSet.js
@@ -35,7 +35,7 @@ const useStyles = makeStyles({
 const DEFAULT_MAXIMUM = 10
 
 function ChangeSet(props) {
-  let { changeSet, isTime12 } = props
+  let { changeSet } = props
 
   const date = new Date(changeSet[0].changed_at)
   const classes = useStyles()
@@ -63,7 +63,6 @@ function ChangeSet(props) {
         action={action}
         afterEmoji={afterEmoji}
         changedAt={change.changed_at}
-        isTime12={isTime12}
       />
     )
   }
@@ -83,7 +82,7 @@ function ChangeSet(props) {
         <CardHeader
           avatar={<GuildAvatar name={guild.name} src={guild} />}
           title={guild.name}
-          subheader={getDateTimeFormatter(isTime12).format(date)}
+          subheader={getDateTimeFormatter().format(date)}
         />
         {blobs}
         {hasMore && (
@@ -106,7 +105,6 @@ function ChangeSet(props) {
 
 ChangeSet.propTypes = {
   changeSet: PropTypes.array.isRequired,
-  isTime12: PropTypes.bool.isRequired
 }
 
 export default ChangeSet

--- a/scripts/components/RecentChanges/ChangeSet.js
+++ b/scripts/components/RecentChanges/ChangeSet.js
@@ -62,6 +62,7 @@ export default function ChangeSet(props) {
         emoji={emoji}
         action={action}
         afterEmoji={afterEmoji}
+        changedAt={change.changed_at}
       />
     )
   }

--- a/scripts/components/RecentChanges/ChangeSet.js
+++ b/scripts/components/RecentChanges/ChangeSet.js
@@ -76,7 +76,7 @@ export default function ChangeSet(props) {
   const blobs = changeSet.map(rows)
 
   return (
-    <Grid item xs={12} md={6}>
+    <Grid item xs={12} sm={6}>
       <Card className={classes.card}>
         <CardHeader
           avatar={<GuildAvatar name={guild.name} src={guild} />}

--- a/scripts/components/RecentChanges/ChangeSet.js
+++ b/scripts/components/RecentChanges/ChangeSet.js
@@ -9,7 +9,7 @@ import AccordionSummary from '@material-ui/core/AccordionSummary'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import makeStyles from '@material-ui/core/styles/makeStyles'
 
-import { DateTimeFormatter } from '../../utils'
+import { getDateTimeFormatter } from '../../utils'
 import ChangeRow from './ChangeRow'
 import Grid from '@material-ui/core/Grid'
 
@@ -81,7 +81,7 @@ export default function ChangeSet(props) {
         <CardHeader
           avatar={<GuildAvatar name={guild.name} src={guild} />}
           title={guild.name}
-          subheader={DateTimeFormatter.format(date)}
+          subheader={getDateTimeFormatter().format(date)}
         />
         {blobs}
         {hasMore && (

--- a/scripts/components/RecentChanges/ChangeSet.js
+++ b/scripts/components/RecentChanges/ChangeSet.js
@@ -34,8 +34,8 @@ const useStyles = makeStyles({
 
 const DEFAULT_MAXIMUM = 10
 
-export default function ChangeSet(props) {
-  let { changeSet } = props
+function ChangeSet(props) {
+  let { changeSet, isTime12 } = props
 
   const date = new Date(changeSet[0].changed_at)
   const classes = useStyles()
@@ -63,6 +63,7 @@ export default function ChangeSet(props) {
         action={action}
         afterEmoji={afterEmoji}
         changedAt={change.changed_at}
+        isTime12={isTime12}
       />
     )
   }
@@ -82,7 +83,7 @@ export default function ChangeSet(props) {
         <CardHeader
           avatar={<GuildAvatar name={guild.name} src={guild} />}
           title={guild.name}
-          subheader={getDateTimeFormatter().format(date)}
+          subheader={getDateTimeFormatter(isTime12).format(date)}
         />
         {blobs}
         {hasMore && (
@@ -105,4 +106,7 @@ export default function ChangeSet(props) {
 
 ChangeSet.propTypes = {
   changeSet: PropTypes.array.isRequired,
+  isTime12: PropTypes.bool.isRequired
 }
+
+export default ChangeSet

--- a/scripts/components/RecentChanges/RecentChanges.js
+++ b/scripts/components/RecentChanges/RecentChanges.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import cloneDeep from 'lodash.clonedeep'
+import PropTypes from 'prop-types'
 
 import { useScrollNearEnd } from '../../hooks'
 import SkeletonChangeSet from './SkeletonChangeSet'
@@ -42,7 +43,7 @@ function groupHistory(changeSets) {
   return changes
 }
 
-export default function RecentChanges() {
+function RecentChanges(props) {
   const [changeSets, setChangeSets] = React.useState(null)
   const [loading, setLoading] = React.useState(false)
   const [earliest, setEarliest] = React.useState(null)
@@ -107,6 +108,12 @@ export default function RecentChanges() {
   }
 
   return Object.entries(changeSets).map(([key, changeSet]) => (
-    <ChangeSet changeSet={changeSet} key={key} />
+    <ChangeSet changeSet={changeSet} key={key} isTime12={props.isTime12} />
   ))
 }
+
+RecentChanges.propTypes = {
+  isTime12: PropTypes.bool.isRequired,
+}
+
+export default RecentChanges

--- a/scripts/components/RecentChanges/RecentChanges.js
+++ b/scripts/components/RecentChanges/RecentChanges.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import cloneDeep from 'lodash.clonedeep'
-import PropTypes from 'prop-types'
 
 import { useScrollNearEnd } from '../../hooks'
 import SkeletonChangeSet from './SkeletonChangeSet'
@@ -43,7 +42,7 @@ function groupHistory(changeSets) {
   return changes
 }
 
-function RecentChanges(props) {
+function RecentChanges() {
   const [changeSets, setChangeSets] = React.useState(null)
   const [loading, setLoading] = React.useState(false)
   const [earliest, setEarliest] = React.useState(null)
@@ -108,12 +107,8 @@ function RecentChanges(props) {
   }
 
   return Object.entries(changeSets).map(([key, changeSet]) => (
-    <ChangeSet changeSet={changeSet} key={key} isTime12={props.isTime12} />
+    <ChangeSet changeSet={changeSet} key={key} />
   ))
-}
-
-RecentChanges.propTypes = {
-  isTime12: PropTypes.bool.isRequired,
 }
 
 export default RecentChanges

--- a/scripts/components/SettingsDialog.js
+++ b/scripts/components/SettingsDialog.js
@@ -9,13 +9,13 @@ import DialogContent from '@material-ui/core/DialogContent'
 import BrightnessLowIcon from '@material-ui/icons/BrightnessLow'
 import BrightnessHighIcon from '@material-ui/icons/BrightnessHigh'
 import Brightness4Icon from '@material-ui/icons/Brightness4'
-import { storageAvailable, warn, getHourFormat } from '../utils'
+import { getDefaultHourFormat, getHourFormat, getKeyWrapper, setKeyWrapper, storageAvailable, warn } from '../utils'
 import useTheme from '@material-ui/core/styles/useTheme'
 import Box from '@material-ui/core/Box'
-import DialogContentText from '@material-ui/core/DialogContentText';
-import AccessAlarmIcon from '@material-ui/icons/AccessAlarm';
-import AccessTimeIcon from '@material-ui/icons/AccessTime';
-import AvTimerIcon from '@material-ui/icons/AvTimer';
+import DialogContentText from '@material-ui/core/DialogContentText'
+import AccessAlarmIcon from '@material-ui/icons/AccessAlarm'
+import AccessTimeIcon from '@material-ui/icons/AccessTime'
+import AvTimerIcon from '@material-ui/icons/AvTimer'
 
 const themeIcons = {
   light: <BrightnessLowIcon fontSize="small" />,
@@ -105,7 +105,7 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: 'auto',
     marginRight: '-12px',
     display: 'block',
-  }
+  },
 }))
 
 export default function SettingsDialog(props) {
@@ -113,7 +113,7 @@ export default function SettingsDialog(props) {
   const onCloseWrapper = useCallback(() => onClose(false), [onClose])
   const handleReloadWrapper = useCallback(
     (randomInt) => handleReload(randomInt),
-    [handleReload]
+    [handleReload],
   )
   const classes = useStyles()
   const theme = useTheme()
@@ -124,8 +124,7 @@ export default function SettingsDialog(props) {
     if (isThemeDisabled) {
       return
     }
-    localStorage.setItem('theme', oppositeTheme[theme.palette.type].toString())
-    localStorage.setItem('automated', 'false')
+    setKeyWrapper('darkTheme', oppositeTheme[theme.palette.type])
     handleReloadWrapper(Math.round(Math.random() * 100))
   }
 
@@ -133,12 +132,9 @@ export default function SettingsDialog(props) {
     if (isHourFormatDisabled) {
       return
     }
-    const oldState = localStorage.getItem('hourFormat');
-    let newState;
-    if (oldState === 'false' || oldState === null) { newState = 'true'; }
-    if (oldState === 'true') { newState = 'false'; }
-    localStorage.setItem('hourFormat', newState)
-    localStorage.setItem('automated', 'false')
+    const defaultHoursFormat = getDefaultHourFormat()
+    const [resIsTime12, resIsTime12LS] = getKeyWrapper('prefers12Hour', defaultHoursFormat)
+    setKeyWrapper('prefers12Hour', !resIsTime12)
     handleReloadWrapper(Math.round(Math.random() * 100))
   }
 

--- a/scripts/components/SettingsDialog.js
+++ b/scripts/components/SettingsDialog.js
@@ -6,7 +6,6 @@ import IconButton from '@material-ui/core/IconButton'
 import CloseIcon from '@material-ui/icons/Close'
 import makeStyles from '@material-ui/core/styles/makeStyles'
 import DialogContent from '@material-ui/core/DialogContent'
-import Typography from '@material-ui/core/Typography'
 import BrightnessLowIcon from '@material-ui/icons/BrightnessLow'
 import BrightnessHighIcon from '@material-ui/icons/BrightnessHigh'
 import Brightness4Icon from '@material-ui/icons/Brightness4'
@@ -81,7 +80,7 @@ function hourFormatIconHandler() {
     if (automated === true) {
       icon = hourFormatIcons.automated
     } else {
-      icon = getHourFormat() ? hourFormatIcons.full : hourFormatIcons.half
+      icon = getHourFormat() ? hourFormatIcons.half : hourFormatIcons.full
     }
   }
 

--- a/scripts/components/SettingsDialog.js
+++ b/scripts/components/SettingsDialog.js
@@ -135,7 +135,7 @@ export default function SettingsDialog(props) {
     }
     const oldState = localStorage.getItem('hourFormat');
     let newState;
-    if (oldState === 'false') { newState = 'true'; }
+    if (oldState === 'false' || oldState === null) { newState = 'true'; }
     if (oldState === 'true') { newState = 'false'; }
     localStorage.setItem('hourFormat', newState)
     localStorage.setItem('automated', 'false')

--- a/scripts/components/SettingsDialog.js
+++ b/scripts/components/SettingsDialog.js
@@ -135,6 +135,7 @@ export default function SettingsDialog(props) {
     const defaultHoursFormat = getDefaultHourFormat()
     const [resIsTime12, resIsTime12LS] = getKeyWrapper('prefers12Hour', defaultHoursFormat)
     setKeyWrapper('prefers12Hour', !resIsTime12)
+    props.setIsTime12(!resIsTime12)
     handleReloadWrapper(Math.round(Math.random() * 100))
   }
 
@@ -191,4 +192,5 @@ SettingsDialog.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   handleReload: PropTypes.func.isRequired,
+  setIsTime12: PropTypes.func.isRequired
 }

--- a/scripts/components/SettingsDialog.js
+++ b/scripts/components/SettingsDialog.js
@@ -94,6 +94,10 @@ const useStyles = makeStyles((theme) => ({
     right: theme.spacing(1),
     top: theme.spacing(1),
   },
+  optionContainer: {
+    display: 'flex',
+    alignItems: 'center',
+  },
   optionText: {
     marginRight: '2.5rem',
     marginBottom: 0,
@@ -170,7 +174,7 @@ export default function SettingsDialog(props) {
             {themeIcon}
           </IconButton>
         </Box>
-        <Box display="flex" alignItems="center" alignContent="space-around">
+        <Box className={classes.optionContainer}>
           <DialogContentText className={classes.optionText}>
             Toggle Hour Format
           </DialogContentText>

--- a/scripts/components/SettingsDialog.js
+++ b/scripts/components/SettingsDialog.js
@@ -85,6 +85,19 @@ export default function SettingsDialog(props) {
     handleReloadWrapper(Math.round(Math.random() * 100))
   }
 
+  function toggleHourFormat() {
+    if (disabled) {
+      return
+    }
+    const oldState = localStorage.getItem('hourFormat');
+    let newState;
+    if (oldState === 'false') { newState = 'true'; }
+    if (oldState === 'true') { newState = 'false'; }
+    localStorage.setItem('hourFormat', newState)
+    localStorage.setItem('automated', 'false')
+    handleReloadWrapper(Math.round(Math.random() * 100))
+  }
+
   return (
     <Dialog
       maxWidth="xs"
@@ -109,6 +122,14 @@ export default function SettingsDialog(props) {
           className={classes.centre}
           disabled={disabled}
           onClick={toggleTheme}
+        >
+          {icon}
+        </IconButton>
+        <IconButton
+          aria-label="Toggle Hour Format"
+          className={classes.centre}
+          disabled={disabled}
+          onClick={toggleHourFormat}
         >
           {icon}
         </IconButton>

--- a/scripts/components/SettingsDialog.js
+++ b/scripts/components/SettingsDialog.js
@@ -9,7 +9,7 @@ import DialogContent from '@material-ui/core/DialogContent'
 import BrightnessLowIcon from '@material-ui/icons/BrightnessLow'
 import BrightnessHighIcon from '@material-ui/icons/BrightnessHigh'
 import Brightness4Icon from '@material-ui/icons/Brightness4'
-import { getDefaultHourFormat, getHourFormat, getKeyWrapper, setKeyWrapper, storageAvailable, warn } from '../utils'
+import { getDefaultHourFormat, getKeyWrapper, setKeyWrapper, storageAvailable } from '../utils'
 import useTheme from '@material-ui/core/styles/useTheme'
 import Box from '@material-ui/core/Box'
 import DialogContentText from '@material-ui/core/DialogContentText'
@@ -34,53 +34,46 @@ const oppositeTheme = {
   dark: false,
 }
 
-function themeIconHandler(theme) {
+function themeIconHandler(defaultTheme) {
   const disabled = !storageAvailable('localStorage')
+  let theme = getKeyWrapper('darkTheme', defaultTheme)
   let icon
-
-  if (disabled === true) {
+  if (theme[1] === false || disabled) {
     icon = themeIcons.automated
   } else {
-    let automated = localStorage.getItem('automated')
-    if (automated === null) {
-      warn('automated was null. Setting automated')
-      localStorage.setItem('automated', 'true')
-      automated = true
-    } else {
-      automated = automated === 'true'
-    }
-
-    if (automated === true) {
+    switch (theme[0]) {
+    case false:
+      icon = themeIcons.light
+      break
+    case true:
+      icon = themeIcons.dark
+      break
+    default:
       icon = themeIcons.automated
-    } else {
-      icon = themeIcons[theme.palette.type]
+      break
     }
   }
 
   return { themeIcon: icon, disabled: disabled }
 }
 
-//TODO - Separate automated from the hour format
-function hourFormatIconHandler() {
+function hourFormatIconHandler(defaultFormat) {
   const disabled = !storageAvailable('localStorage')
+  let theme = getKeyWrapper('prefers12Hour', defaultFormat)
   let icon
-
-  if (disabled === true) {
+  if (theme[1] === false || disabled) {
     icon = hourFormatIcons.automated
   } else {
-    let automated = localStorage.getItem('automated')
-    if (automated === null) {
-      warn('automated was null. Setting automated')
-      localStorage.setItem('automated', 'true')
-      automated = true
-    } else {
-      automated = automated === 'true'
-    }
-
-    if (automated === true) {
+    switch (theme[0]) {
+    case false:
+      icon = hourFormatIcons.full
+      break
+    case true:
+      icon = hourFormatIcons.half
+      break
+    default:
       icon = hourFormatIcons.automated
-    } else {
-      icon = getHourFormat() ? hourFormatIcons.half : hourFormatIcons.full
+      break
     }
   }
 
@@ -118,7 +111,7 @@ export default function SettingsDialog(props) {
   const classes = useStyles()
   const theme = useTheme()
   const { themeIcon, isThemeDisabled } = themeIconHandler(theme)
-  const { hourFormatIcon, isHourFormatDisabled } = hourFormatIconHandler()
+  const { hourFormatIcon, isHourFormatDisabled } = hourFormatIconHandler(getDefaultHourFormat())
 
   function toggleTheme() {
     if (isThemeDisabled) {
@@ -132,10 +125,8 @@ export default function SettingsDialog(props) {
     if (isHourFormatDisabled) {
       return
     }
-    const defaultHoursFormat = getDefaultHourFormat()
-    const [resIsTime12, resIsTime12LS] = getKeyWrapper('prefers12Hour', defaultHoursFormat)
+    const [resIsTime12] = getKeyWrapper('prefers12Hour', getDefaultHourFormat())
     setKeyWrapper('prefers12Hour', !resIsTime12)
-    props.setIsTime12(!resIsTime12)
     handleReloadWrapper(Math.round(Math.random() * 100))
   }
 
@@ -192,5 +183,4 @@ SettingsDialog.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   handleReload: PropTypes.func.isRequired,
-  setIsTime12: PropTypes.func.isRequired
 }

--- a/scripts/components/SettingsDialog.js
+++ b/scripts/components/SettingsDialog.js
@@ -57,8 +57,7 @@ function iconHandler(key, icons) {
       break
     }
     // eslint-disable-next-line no-empty
-    default: {
-    }
+    default: {}
     }
   }
   return icon
@@ -67,30 +66,14 @@ function iconHandler(key, icons) {
 function getTooltipString(key) {
   const value = localStorage.getItem(key)
   let string = 'Toggle to '
-  
+
   if (key === 'darkTheme') {
-    switch (value) {
-    case '2':
-      return string + 'Dark Theme'
-    case '1':
-      return string + 'Light Theme'
-    default:
-      return 'Toggle Theme'
-    }
+    return `${string}${value === '2' ? 'Dark' : 'Light'} Theme`
+  } else if (key === 'prefers12Hour') {
+    return `${string}${value === '2' ? '12h' : '24h'} Theme`
   }
+  return `${string}${key}`
 
-  if (key === 'prefers12Hour') {
-    switch (value) {
-    case '2':
-      return string + '12h Format'
-    case '1':
-      return string + '24h Format'
-    default:
-      return 'Toggle Hour Format'
-    }
-  }
-
-  return ''
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -114,7 +97,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-export default function SettingsDialog(props) {
+function SettingsDialog(props) {
   const { open, onClose, handleReload } = props
   const onCloseWrapper = useCallback(() => onClose(false), [onClose])
   const handleReloadWrapper = useCallback(
@@ -196,3 +179,5 @@ SettingsDialog.propTypes = {
   onClose: PropTypes.func.isRequired,
   handleReload: PropTypes.func.isRequired,
 }
+
+export default SettingsDialog

--- a/scripts/components/SettingsDialog.js
+++ b/scripts/components/SettingsDialog.js
@@ -64,6 +64,35 @@ function iconHandler(key, icons) {
   return icon
 }
 
+function getTooltipString(key) {
+  const value = localStorage.getItem(key)
+  let string = 'Toggle to '
+  
+  if (key === 'darkTheme') {
+    switch (value) {
+    case '2':
+      return string + 'Dark Theme'
+    case '1':
+      return string + 'Light Theme'
+    default:
+      return 'Toggle Theme'
+    }
+  }
+
+  if (key === 'prefers12Hour') {
+    switch (value) {
+    case '2':
+      return string + '12h Format'
+    case '1':
+      return string + '24h Format'
+    default:
+      return 'Toggle Hour Format'
+    }
+  }
+
+  return ''
+}
+
 const useStyles = makeStyles((theme) => ({
   closeIcon: {
     position: 'absolute',
@@ -96,6 +125,8 @@ export default function SettingsDialog(props) {
   const theme = useTheme()
   const themeIcon = iconHandler('darkTheme', themeIcons)
   const hourFormatIcon = iconHandler('prefers12Hour', hourFormatIcons)
+  const themeTooltip = getTooltipString('darkTheme')
+  const hourFormatTooltip = getTooltipString('prefers12Hour')
 
   function toggleTheme() {
     setKeyWrapper('darkTheme', oppositeTheme[theme.palette.type])
@@ -131,9 +162,9 @@ export default function SettingsDialog(props) {
           <DialogContentText className={classes.optionText}>
             Toggle Theme
           </DialogContentText>
-          <Tooltip title="Toggle Theme" arrow>
+          <Tooltip title={themeTooltip} arrow>
             <IconButton
-              aria-label="Toggle Theme"
+              aria-label={themeTooltip}
               className={classes.optionButton}
               onClick={toggleTheme}
             >
@@ -145,9 +176,9 @@ export default function SettingsDialog(props) {
           <DialogContentText className={classes.optionText}>
             Toggle Hour Format
           </DialogContentText>
-          <Tooltip title="Toggle Hour Format" arrow>
+          <Tooltip title={hourFormatTooltip} arrow>
             <IconButton
-              aria-label="Toggle Hour Format"
+              aria-label={hourFormatTooltip}
               className={classes.optionButton}
               onClick={toggleHourFormat}
             >

--- a/scripts/pages/changepage.js
+++ b/scripts/pages/changepage.js
@@ -3,8 +3,9 @@ import Typography from '@material-ui/core/Typography'
 import RecentChangesWrapper from '../components/RecentChanges/RecentChanges'
 import Container from '@material-ui/core/Container'
 import Grid from '@material-ui/core/Grid'
+import PropTypes from 'prop-types'
 
-function ChangePage() {
+function ChangePage(props) {
   return (
     <Container maxWidth="md">
       <Typography variant="h4">Global Blob Changelog</Typography>
@@ -13,10 +14,14 @@ function ChangePage() {
         servers.
       </p>
       <Grid container spacing={3}>
-        <RecentChangesWrapper />
+        <RecentChangesWrapper isTime12={props.isTime12} />
       </Grid>
     </Container>
   )
+}
+
+ChangePage.propTypes = {
+  isTime12: PropTypes.bool.isRequired,
 }
 
 export default ChangePage

--- a/scripts/pages/changepage.js
+++ b/scripts/pages/changepage.js
@@ -3,9 +3,8 @@ import Typography from '@material-ui/core/Typography'
 import RecentChangesWrapper from '../components/RecentChanges/RecentChanges'
 import Container from '@material-ui/core/Container'
 import Grid from '@material-ui/core/Grid'
-import PropTypes from 'prop-types'
 
-function ChangePage(props) {
+function ChangePage() {
   return (
     <Container maxWidth="md">
       <Typography variant="h4">Global Blob Changelog</Typography>
@@ -14,14 +13,10 @@ function ChangePage(props) {
         servers.
       </p>
       <Grid container spacing={3}>
-        <RecentChangesWrapper isTime12={props.isTime12} />
+        <RecentChangesWrapper />
       </Grid>
     </Container>
   )
-}
-
-ChangePage.propTypes = {
-  isTime12: PropTypes.bool.isRequired,
 }
 
 export default ChangePage

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -59,13 +59,17 @@ export const DateTimeFormatter24 = new Intl.DateTimeFormat('en-US', {
   hour12: false
 })
 
-export function getHourFormat() {
+export function getDefaultHourFormat() {
   const date = new Intl.DateTimeFormat('default', { hour: 'numeric', minute: 'numeric' }).resolvedOptions();
   return date.hour12;
 }
 
+export function getHourFormat() {
+  return localStorage.getItem('hourFormat') === 'true';
+}
+
 export function getDateTimeFormatter() {
-  if (localStorage.getItem('hourFormat') === 'true') {
+  if (getHourFormat()) {
     return DateTimeFormatter;
   }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -56,30 +56,16 @@ export const DateTimeFormatter24 = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   hour: 'numeric',
   minute: 'numeric',
-  hour12: false
+  hour12: false,
 })
 
 export function getDefaultHourFormat() {
-  const date = new Intl.DateTimeFormat('default', { hour: 'numeric', minute: 'numeric' }).resolvedOptions();
-  return date.hour12;
+  const date = new Intl.DateTimeFormat('default', { hour: 'numeric', minute: 'numeric' }).resolvedOptions()
+  return date.hour12
 }
 
 export function getHourFormat() {
-  return localStorage.getItem('hourFormat') === 'true';
-}
-
-export function getDateTimeFormatter() {
-  let isTime12 = false;
-
-  if (localStorage.getItem('hourFormat') === null) {
-    isTime12 = getDefaultHourFormat();
-  }
-
-  if (getHourFormat() || isTime12) {
-    return DateTimeFormatter;
-  }
-
-  return DateTimeFormatter24;
+  return localStorage.getItem('hourFormat') === 'true'
 }
 
 export function storageAvailable(type) {
@@ -130,7 +116,7 @@ export function calculateEmojiCount(data) {
  * @param {Number} chunkSize The size of the chunk
  * @returns {Array} The chunked array
  */
-export function chunker(inputArray, chunkSize= 6) {
+export function chunker(inputArray, chunkSize = 6) {
   return inputArray.reduce((resultArray, item, index) => {
     const chunkIndex = Math.floor(index / chunkSize)
 
@@ -142,4 +128,65 @@ export function chunker(inputArray, chunkSize= 6) {
 
     return resultArray
   }, [])
+}
+
+/**
+ * @param {String} key The key to check with
+ * @param {boolean} value The value to set
+ * @returns {boolean} If it was successful
+ */
+export function setKeyWrapper(key, value) {
+  const trans = {
+    true: 1,
+    false: 2,
+  }
+
+  if (storageAvailable('localStorage')) {
+    localStorage.setItem(key, trans[value])
+    return true
+  }
+  return false
+}
+
+/**
+ * @param {String} key The key to check with
+ * @param {Boolean} value The value in case there isn't a key/LS
+ * @returns {[Boolean, Boolean]} Returns Value & if it used the LS
+ */
+export function getKeyWrapper(key, value) {
+  const trans = {
+    1: true,
+    2: false,
+    3: 'automated',
+  }
+
+  // If I can use LS then use it
+  if (storageAvailable('localStorage')) {
+    const keyCheck = localStorage.getItem(key)
+    // If it is automated
+    if (keyCheck === '3') {
+      return [value, false]
+    } else if (Object.keys(trans).includes(keyCheck)) {
+      // Return the fetched value as something useful
+      return [trans[keyCheck], true]
+    }
+    // If key not in DB
+    warn(`Setting key for ${key}`)
+    setKeyWrapper(key, value)
+    return [value, false]
+  }
+  // Can't use LS, have whatever I'm given
+  return [value, false]
+}
+
+/**
+ * @param {Boolean} isTime12 Is 12 hour
+ * @returns {Intl.DateTimeFormat} Date formatter
+ */
+export function getDateTimeFormatter(isTime12) {
+  if (getHourFormat() || isTime12) {
+    return DateTimeFormatter
+  }
+
+  return DateTimeFormatter24
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -64,10 +64,6 @@ export function getDefaultHourFormat() {
   return date.hour12
 }
 
-export function getHourFormat() {
-  return localStorage.getItem('hourFormat') === 'true'
-}
-
 export function storageAvailable(type) {
   let storage
   try {
@@ -179,12 +175,15 @@ export function getKeyWrapper(key, value) {
   return [value, false]
 }
 
+export function getHourFormat() {
+  return getKeyWrapper('prefers12Hour', getDefaultHourFormat())[0]
+}
+
 /**
- * @param {Boolean} isTime12 Is 12 hour
  * @returns {Intl.DateTimeFormat} Date formatter
  */
-export function getDateTimeFormatter(isTime12) {
-  if (getHourFormat() || isTime12) {
+export function getDateTimeFormatter() {
+  if (getHourFormat()) {
     return DateTimeFormatter
   }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -49,6 +49,29 @@ export const DateTimeFormatter = new Intl.DateTimeFormat('en-US', {
   minute: 'numeric',
 })
 
+export const DateTimeFormatter24 = new Intl.DateTimeFormat('en-US', {
+  weekday: 'long',
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  hour12: false
+})
+
+export function getHourFormat() {
+  const date = new Intl.DateTimeFormat('default', { hour: 'numeric', minute: 'numeric' }).resolvedOptions();
+  return date.hour12;
+}
+
+export function getDateTimeFormatter() {
+  if (localStorage.getItem('hourFormat') === 'true') {
+    return DateTimeFormatter;
+  }
+
+  return DateTimeFormatter24;
+}
+
 export function storageAvailable(type) {
   let storage
   try {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -69,7 +69,13 @@ export function getHourFormat() {
 }
 
 export function getDateTimeFormatter() {
-  if (getHourFormat()) {
+  let isTime12 = false;
+
+  if (localStorage.getItem('hourFormat') === null) {
+    isTime12 = getDefaultHourFormat();
+  }
+
+  if (getHourFormat() || isTime12) {
     return DateTimeFormatter;
   }
 


### PR DESCRIPTION
This PR does the following:
- Adds support for the 24h hour format
- Adds a toggle for the hour format
- Overhaul the appearance of the settings dialog
- Overhaul the settings system (Thank you, Oceanlord)
- Add timestamp tooltips to the changelog rows
- Improve the changelog page's mobile compatibility