### PR TITLE
Remove redirected zip download

### DIFF
--- a/scripts/components/Home/OfficialServers.js
+++ b/scripts/components/Home/OfficialServers.js
@@ -37,8 +37,8 @@ function OfficialServers(props) {
         </Typography>
         <Typography variant="body2">
           All blobs from the official servers can be downloaded{' '}
-          <Link href="https://blobs.gg/blobs.zip">here</Link>. Make sure to
-          follow the license.
+          <Link href="https://files.snowyluma.dev/blobs.zip">here</Link>. Make
+          sure to follow the license.
         </Typography>
       </div>
     </>


### PR DESCRIPTION
I'd like to switch hosting entirely to the Cloudflare Pages beta, however since it does not support redirects or using a worker in front of the page yet this redirect will break for now.

All links in the Discord server have already been updated a month or two ago.