### PR TITLE
[package] Add ability to analyze makeup of the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ yarn.lock
 # parcel
 /.parcel-cache
 /dist
+/parcel-bundle-reports
 
 # macOS
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,10 @@
         "@babel/plugin-transform-runtime": "^7.14.5",
         "@babel/preset-react": "^7.14.5",
         "@babel/runtime": "^7.14.8",
+        "@parcel/reporter-bundle-analyzer": "^2.0.0-beta.3.1",
         "@parcel/transformer-svg-react": "2.0.0-beta.3.1",
         "@welldone-software/why-did-you-render": "^6.2.0",
+        "cross-env": "^7.0.3",
         "eslint": "^7.32.0",
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-react": "^7.24.0",
@@ -2022,6 +2024,213 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer": {
+      "version": "2.0.0-nightly.1694",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-analyzer/-/reporter-bundle-analyzer-2.0.0-nightly.1694.tgz",
+      "integrity": "sha512-avRxTF1tHXRnoufI4Fguv9Z5PoBpvSG0EyPR9RhHaL7DEGXFDw+Rg9We0z6aaEaQYAfSZ0KnTp9cWXjjvIlkbw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.0.0-nightly.72+a0d19756",
+        "@parcel/utils": "2.0.0-nightly.72+a0d19756",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "parcel": "^2.0.0-alpha.3.1"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/codeframe": {
+      "version": "2.0.0-nightly.72",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.0.0-nightly.72.tgz",
+      "integrity": "sha512-qpfzQlJpqlT9KPIVsooigHdLbscO00U+tZ0E0YdjYLd9PsBwAiuYEqh1AqoRPTy8eOu/U0bAakD4yU5n0KkwNw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "emphasize": "^2.1.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/diagnostic": {
+      "version": "2.0.0-nightly.72",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0-nightly.72.tgz",
+      "integrity": "sha512-9Z3rr0sK0iJlYodrLtDuXbh3SFMd9xsf8L1a8MZ5WV1+MskGS/gIIC829EN7l7Vw8hWXqr6OX6lTg0dDCClblg==",
+      "dev": true,
+      "dependencies": {
+        "json-source-map": "^0.6.1",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/events": {
+      "version": "2.0.0-nightly.72",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0-nightly.72.tgz",
+      "integrity": "sha512-TQCiFzLEqN74jXRFZ9/FFhO3//POaCbYopi3R9di+3JkbjIqE+lwsuuyGmnZhsQWPaggiZDzF9gIOTWeSzCH+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/logger": {
+      "version": "2.0.0-nightly.72",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-nightly.72.tgz",
+      "integrity": "sha512-vieHepW22Sj+yqs7yW2b5nbbkv9nxn1ilmeuJyGVXA4hw3FCKRLttZPv/nE6sN3KeXt77pvrrO3kCvhEcnby8A==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.0.0-nightly.72+a0d19756",
+        "@parcel/events": "2.0.0-nightly.72+a0d19756"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/markdown-ansi": {
+      "version": "2.0.0-nightly.72",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-nightly.72.tgz",
+      "integrity": "sha512-j0HojLH+e0L8naFHjcDwEOnSzjh9lH32bxkoHZgibg2MYuGssB/X6EQbzf+Lw135i+hTEPnPzYZBhWnofTKogw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/plugin": {
+      "version": "2.0.0-nightly.72",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.0.0-nightly.72.tgz",
+      "integrity": "sha512-R1COpRwbinYmOotrE9bpWqeDhdpT6tZT3VBjlqeq/snaQydfC1No4GYHsZYANCg6/U+QJIfRZz12dLDQfL4i4w==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/types": "2.0.0-nightly.72+a0d19756"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/types": {
+      "version": "2.0.0-nightly.72",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.0.0-nightly.72.tgz",
+      "integrity": "sha512-NJfVFyUVUjZf3NrFb0CRQk5MPAyr/zpfYZw81eW9JwjFMhBumqW5kN/Qy75UXNznOBhl28q4ZGYQUbucnJxTrw==",
+      "dev": true
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/utils": {
+      "version": "2.0.0-nightly.72",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-nightly.72.tgz",
+      "integrity": "sha512-JaGKf3fArez1WMjzkJrUMHQ/kjRRfRJKOYS00O2d9aUYSlaUA0z744JUl9oTIspnWtqOhNfWEc1IU6mfTCk1dQ==",
+      "dev": true,
+      "dependencies": {
+        "@iarna/toml": "^2.2.0",
+        "@parcel/codeframe": "2.0.0-nightly.72+a0d19756",
+        "@parcel/diagnostic": "2.0.0-nightly.72+a0d19756",
+        "@parcel/logger": "2.0.0-nightly.72+a0d19756",
+        "@parcel/markdown-ansi": "2.0.0-nightly.72+a0d19756",
+        "ansi-html": "^0.0.7",
+        "chalk": "^2.4.2",
+        "clone": "^2.1.1",
+        "fast-glob": "^3.0.4",
+        "is-glob": "^4.0.0",
+        "is-url": "^1.2.2",
+        "js-levenshtein": "^1.1.6",
+        "json5": "^1.0.1",
+        "micromatch": "^4.0.2",
+        "node-forge": "^0.8.1",
+        "nullthrows": "^1.1.1",
+        "resolve": "^1.12.0",
+        "serialize-to-js": "^3.0.1",
+        "terser": "^3.7.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/emphasize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emphasize/-/emphasize-2.1.0.tgz",
+      "integrity": "sha512-wRlO0Qulw2jieQynsS3STzTabIhHCyjTjZraSkchOiT8rdvWZlahJAJ69HRxwGkv2NThmci2MSnDfJ60jB39tw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.0",
+        "highlight.js": "~9.12.0",
+        "lowlight": "~1.9.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/lowlight": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
+      "integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+      "dev": true,
+      "dependencies": {
+        "fault": "^1.0.2",
+        "highlight.js": "~9.12.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/node-forge": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/terser": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.19.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.10"
+      },
+      "bin": {
+        "terser": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@parcel/reporter-cli": {
@@ -4301,6 +4510,24 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -7646,6 +7873,15 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -11777,6 +12013,15 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/serialize-to-js": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.1.1.tgz",
+      "integrity": "sha512-F+NGU0UHMBO4Q965tjw7rvieNVjlH6Lqi2emq/Lc9LUURYJbiCzmpi4Cy1OOjjVPtxu0c+NE85LU6968Wko5ZA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/serve-handler": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
@@ -14858,6 +15103,171 @@
         "@parcel/types": "2.0.0-beta.3.1"
       }
     },
+    "@parcel/reporter-bundle-analyzer": {
+      "version": "2.0.0-nightly.1694",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-analyzer/-/reporter-bundle-analyzer-2.0.0-nightly.1694.tgz",
+      "integrity": "sha512-avRxTF1tHXRnoufI4Fguv9Z5PoBpvSG0EyPR9RhHaL7DEGXFDw+Rg9We0z6aaEaQYAfSZ0KnTp9cWXjjvIlkbw==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.0.0-nightly.72+a0d19756",
+        "@parcel/utils": "2.0.0-nightly.72+a0d19756",
+        "nullthrows": "^1.1.1"
+      },
+      "dependencies": {
+        "@parcel/codeframe": {
+          "version": "2.0.0-nightly.72",
+          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.0.0-nightly.72.tgz",
+          "integrity": "sha512-qpfzQlJpqlT9KPIVsooigHdLbscO00U+tZ0E0YdjYLd9PsBwAiuYEqh1AqoRPTy8eOu/U0bAakD4yU5n0KkwNw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "emphasize": "^2.1.0"
+          }
+        },
+        "@parcel/diagnostic": {
+          "version": "2.0.0-nightly.72",
+          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0-nightly.72.tgz",
+          "integrity": "sha512-9Z3rr0sK0iJlYodrLtDuXbh3SFMd9xsf8L1a8MZ5WV1+MskGS/gIIC829EN7l7Vw8hWXqr6OX6lTg0dDCClblg==",
+          "dev": true,
+          "requires": {
+            "json-source-map": "^0.6.1",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "@parcel/events": {
+          "version": "2.0.0-nightly.72",
+          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0-nightly.72.tgz",
+          "integrity": "sha512-TQCiFzLEqN74jXRFZ9/FFhO3//POaCbYopi3R9di+3JkbjIqE+lwsuuyGmnZhsQWPaggiZDzF9gIOTWeSzCH+A==",
+          "dev": true
+        },
+        "@parcel/logger": {
+          "version": "2.0.0-nightly.72",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-nightly.72.tgz",
+          "integrity": "sha512-vieHepW22Sj+yqs7yW2b5nbbkv9nxn1ilmeuJyGVXA4hw3FCKRLttZPv/nE6sN3KeXt77pvrrO3kCvhEcnby8A==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.0.0-nightly.72+a0d19756",
+            "@parcel/events": "2.0.0-nightly.72+a0d19756"
+          }
+        },
+        "@parcel/markdown-ansi": {
+          "version": "2.0.0-nightly.72",
+          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-nightly.72.tgz",
+          "integrity": "sha512-j0HojLH+e0L8naFHjcDwEOnSzjh9lH32bxkoHZgibg2MYuGssB/X6EQbzf+Lw135i+hTEPnPzYZBhWnofTKogw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2"
+          }
+        },
+        "@parcel/plugin": {
+          "version": "2.0.0-nightly.72",
+          "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.0.0-nightly.72.tgz",
+          "integrity": "sha512-R1COpRwbinYmOotrE9bpWqeDhdpT6tZT3VBjlqeq/snaQydfC1No4GYHsZYANCg6/U+QJIfRZz12dLDQfL4i4w==",
+          "dev": true,
+          "requires": {
+            "@parcel/types": "2.0.0-nightly.72+a0d19756"
+          }
+        },
+        "@parcel/types": {
+          "version": "2.0.0-nightly.72",
+          "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.0.0-nightly.72.tgz",
+          "integrity": "sha512-NJfVFyUVUjZf3NrFb0CRQk5MPAyr/zpfYZw81eW9JwjFMhBumqW5kN/Qy75UXNznOBhl28q4ZGYQUbucnJxTrw==",
+          "dev": true
+        },
+        "@parcel/utils": {
+          "version": "2.0.0-nightly.72",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-nightly.72.tgz",
+          "integrity": "sha512-JaGKf3fArez1WMjzkJrUMHQ/kjRRfRJKOYS00O2d9aUYSlaUA0z744JUl9oTIspnWtqOhNfWEc1IU6mfTCk1dQ==",
+          "dev": true,
+          "requires": {
+            "@iarna/toml": "^2.2.0",
+            "@parcel/codeframe": "2.0.0-nightly.72+a0d19756",
+            "@parcel/diagnostic": "2.0.0-nightly.72+a0d19756",
+            "@parcel/logger": "2.0.0-nightly.72+a0d19756",
+            "@parcel/markdown-ansi": "2.0.0-nightly.72+a0d19756",
+            "ansi-html": "^0.0.7",
+            "chalk": "^2.4.2",
+            "clone": "^2.1.1",
+            "fast-glob": "^3.0.4",
+            "is-glob": "^4.0.0",
+            "is-url": "^1.2.2",
+            "js-levenshtein": "^1.1.6",
+            "json5": "^1.0.1",
+            "micromatch": "^4.0.2",
+            "node-forge": "^0.8.1",
+            "nullthrows": "^1.1.1",
+            "resolve": "^1.12.0",
+            "serialize-to-js": "^3.0.1",
+            "terser": "^3.7.3"
+          }
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "emphasize": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/emphasize/-/emphasize-2.1.0.tgz",
+          "integrity": "sha512-wRlO0Qulw2jieQynsS3STzTabIhHCyjTjZraSkchOiT8rdvWZlahJAJ69HRxwGkv2NThmci2MSnDfJ60jB39tw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.0",
+            "highlight.js": "~9.12.0",
+            "lowlight": "~1.9.0"
+          }
+        },
+        "highlight.js": {
+          "version": "9.12.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+          "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+          "dev": true
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "lowlight": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
+          "integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+          "dev": true,
+          "requires": {
+            "fault": "^1.0.2",
+            "highlight.js": "~9.12.0"
+          }
+        },
+        "node-forge": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+          "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "terser": {
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+          "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.19.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.10"
+          }
+        }
+      }
+    },
     "@parcel/reporter-cli": {
       "version": "2.0.0-beta.3.1",
       "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.0.0-beta.3.1.tgz",
@@ -16570,6 +16980,15 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {
@@ -19146,6 +19565,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
       "dev": true
     },
     "js-tokens": {
@@ -22345,6 +22770,12 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+    },
+    "serialize-to-js": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.1.1.tgz",
+      "integrity": "sha512-F+NGU0UHMBO4Q965tjw7rvieNVjlH6Lqi2emq/Lc9LUURYJbiCzmpi4Cy1OOjjVPtxu0c+NE85LU6968Wko5ZA==",
+      "dev": true
     },
     "serve-handler": {
       "version": "6.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "blobs.gg",
       "version": "0.0.1",
       "dependencies": {
         "@emotion/react": "^11.4.0",
@@ -32,7 +33,6 @@
         "@parcel/reporter-bundle-analyzer": "^2.0.0-beta.3.1",
         "@parcel/transformer-svg-react": "2.0.0-beta.3.1",
         "@welldone-software/why-did-you-render": "^6.2.0",
-        "cross-env": "^7.0.3",
         "eslint": "^7.32.0",
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-react": "^7.24.0",
@@ -1432,6 +1432,23 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/hash": {
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.0.0-rc.0.tgz",
+      "integrity": "sha512-qbR1evXfjR4t0LhY3z32nrGnPh32vsuafS6rrS4JOJyD7mbOsHUKsT1Vkggh3R5Jv0sMtuRqlYngK59WO/Yzbg==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "xxhash-wasm": "^0.4.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/logger": {
       "version": "2.0.0-beta.3.1",
       "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-beta.3.1.tgz",
@@ -2027,153 +2044,486 @@
       }
     },
     "node_modules/@parcel/reporter-bundle-analyzer": {
-      "version": "2.0.0-nightly.1694",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-analyzer/-/reporter-bundle-analyzer-2.0.0-nightly.1694.tgz",
-      "integrity": "sha512-avRxTF1tHXRnoufI4Fguv9Z5PoBpvSG0EyPR9RhHaL7DEGXFDw+Rg9We0z6aaEaQYAfSZ0KnTp9cWXjjvIlkbw==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-analyzer/-/reporter-bundle-analyzer-2.0.0-rc.0.tgz",
+      "integrity": "sha512-22OUWJ4SVlxx/7kqippwGpJ3qsaEiiUlxzYNfI3hfJvi/PPu0urspaPF2X5tIW0G98YeD/O0ytiuFPROUSa6AQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.0.0-nightly.72+a0d19756",
-        "@parcel/utils": "2.0.0-nightly.72+a0d19756",
+        "@parcel/plugin": "2.0.0-rc.0",
+        "@parcel/utils": "2.0.0-rc.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 10.0.0",
+        "node": ">= 12.0.0",
         "parcel": "^2.0.0-alpha.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/cache": {
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.0.0-rc.0.tgz",
+      "integrity": "sha512-XW3evoovrpr661Ts7Pgw6OTQ+TC63yCffd/+e4qvxD+/nmvHLRUnJR66gRX9GzbG7xaEfJvgcENbxx1CHNm3WA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/logger": "2.0.0-rc.0",
+        "@parcel/utils": "2.0.0-rc.0",
+        "lmdb-store": "^1.5.5"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.0.0-alpha.3.1"
       }
     },
     "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/codeframe": {
-      "version": "2.0.0-nightly.72",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.0.0-nightly.72.tgz",
-      "integrity": "sha512-qpfzQlJpqlT9KPIVsooigHdLbscO00U+tZ0E0YdjYLd9PsBwAiuYEqh1AqoRPTy8eOu/U0bAakD4yU5n0KkwNw==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.0.0-rc.0.tgz",
+      "integrity": "sha512-wJR/5y1xAutpCPTpDSEpSO1d5Tm6GYQZ1kNS9jx+J7KVcwpwB/ypw9mon+4kFoyegkc98YaJpTm3jlL/bBJblg==",
       "dev": true,
       "dependencies": {
-        "chalk": "^2.4.2",
-        "emphasize": "^2.1.0"
+        "chalk": "^4.1.0",
+        "emphasize": "^4.2.0",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/diagnostic": {
-      "version": "2.0.0-nightly.72",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0-nightly.72.tgz",
-      "integrity": "sha512-9Z3rr0sK0iJlYodrLtDuXbh3SFMd9xsf8L1a8MZ5WV1+MskGS/gIIC829EN7l7Vw8hWXqr6OX6lTg0dDCClblg==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0-rc.0.tgz",
+      "integrity": "sha512-s8hzLkUcgFqwfuCxHHuqx0zyeDU+GYtz69StWlCECXumHJMS0iaomE4IaKW5fsIMsdgndg7g4/yZc2eMXiHR1Q==",
       "dev": true,
       "dependencies": {
         "json-source-map": "^0.6.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/events": {
-      "version": "2.0.0-nightly.72",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0-nightly.72.tgz",
-      "integrity": "sha512-TQCiFzLEqN74jXRFZ9/FFhO3//POaCbYopi3R9di+3JkbjIqE+lwsuuyGmnZhsQWPaggiZDzF9gIOTWeSzCH+A==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0-rc.0.tgz",
+      "integrity": "sha512-k/fqhFXyQQYqo/2Y0pfxz97usoW14+g5hFO1Kfnto3t5l46M8sU65Di6qLHeTEVkO2cWh/alc7N8QxlcXmxO3Q==",
       "dev": true,
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/fs": {
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.0.0-rc.0.tgz",
+      "integrity": "sha512-vUXkiNiHa6cc9QrV4GGi40ID27aH5a/GNZ8G2EZxnPtC7FXjrI359CAt7qU8rGxOyPVECGNIwBr+e31p+Xg/Lg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/fs-search": "2.0.0-rc.0",
+        "@parcel/fs-write-stream-atomic": "2.0.0-rc.0",
+        "@parcel/types": "2.0.0-rc.0",
+        "@parcel/utils": "2.0.0-rc.0",
+        "@parcel/watcher": "2.0.0-alpha.10",
+        "@parcel/workers": "2.0.0-rc.0",
+        "graceful-fs": "^4.2.4",
+        "mkdirp": "^0.5.1",
+        "ncp": "^2.0.0",
+        "nullthrows": "^1.1.1",
+        "rimraf": "^3.0.2",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.0.0-alpha.3.1"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/fs-search": {
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.0.0-rc.0.tgz",
+      "integrity": "sha512-x/gdmnxWIhuP6kVUe3u8fiY5JBCmALHNJIPNDGdoVada1CEEHF+DJtQG7LT+LIcPFeAqXT6qx05HrgO94KLaUQ==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/fs-write-stream-atomic": {
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-write-stream-atomic/-/fs-write-stream-atomic-2.0.0-rc.0.tgz",
+      "integrity": "sha512-KQ9FbE+ee2nzEtZwdVcxup1uWGfyfKj0cDsbxfak+oMubDTb3ycQlyCAnVPKoybvxqpsTG+TKDXObDz8SBCF1A==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^1.0.2",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/logger": {
-      "version": "2.0.0-nightly.72",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-nightly.72.tgz",
-      "integrity": "sha512-vieHepW22Sj+yqs7yW2b5nbbkv9nxn1ilmeuJyGVXA4hw3FCKRLttZPv/nE6sN3KeXt77pvrrO3kCvhEcnby8A==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-rc.0.tgz",
+      "integrity": "sha512-gUbEN0iTM0E8Vb0qhLev/AcHyKc3McVWOSZQDC31CQ0DpPY8KPVmDR4tEL+hC0YEl6ekpG2c41F5XpH2mzTawg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.0.0-nightly.72+a0d19756",
-        "@parcel/events": "2.0.0-nightly.72+a0d19756"
+        "@parcel/diagnostic": "2.0.0-rc.0",
+        "@parcel/events": "2.0.0-rc.0"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/markdown-ansi": {
-      "version": "2.0.0-nightly.72",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-nightly.72.tgz",
-      "integrity": "sha512-j0HojLH+e0L8naFHjcDwEOnSzjh9lH32bxkoHZgibg2MYuGssB/X6EQbzf+Lw135i+hTEPnPzYZBhWnofTKogw==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-rc.0.tgz",
+      "integrity": "sha512-ipR71hKCpqq9aXaPCordBPETYP/QyrN2t2Ra7tPPCvNful44i0JqWakPeSrDO1HJT1s1GI1lGpIk+ytc/5PCCg==",
       "dev": true,
       "dependencies": {
-        "chalk": "^2.4.2"
+        "chalk": "^4.1.0"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/package-manager": {
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.0.0-rc.0.tgz",
+      "integrity": "sha512-QA1B7FViEMB0CpEeEV1oCqIDFHDReYWL38NnwWesLiewIAeIZHLCHqN35ClCK84F8NnCUp9uMymDv61rwJlq9A==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.0.0-rc.0",
+        "@parcel/fs": "2.0.0-rc.0",
+        "@parcel/logger": "2.0.0-rc.0",
+        "@parcel/types": "2.0.0-rc.0",
+        "@parcel/utils": "2.0.0-rc.0",
+        "@parcel/workers": "2.0.0-rc.0",
+        "command-exists": "^1.2.6",
+        "cross-spawn": "^6.0.4",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.4.1",
+        "split2": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.0.0-alpha.3.1"
       }
     },
     "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/plugin": {
-      "version": "2.0.0-nightly.72",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.0.0-nightly.72.tgz",
-      "integrity": "sha512-R1COpRwbinYmOotrE9bpWqeDhdpT6tZT3VBjlqeq/snaQydfC1No4GYHsZYANCg6/U+QJIfRZz12dLDQfL4i4w==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.0.0-rc.0.tgz",
+      "integrity": "sha512-dCfnWnkoqsPijEHKhisENDiGBUUCLuZfjPkVGqMcKBpLhv6bnh3ivmXyC9bcJBZJ8BV9Ytltj+ooOyFOMQRJnQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/types": "2.0.0-nightly.72+a0d19756"
+        "@parcel/types": "2.0.0-rc.0"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/source-map": {
+      "version": "2.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.0-rc.6.tgz",
+      "integrity": "sha512-qtXLd9dbxWx/ybe1dduAzAGzb7iTSQv3imNZo7pVyEtSaCcphg+rTmY8/Fg3MQqqu7of/2+tEqNAGMz8nOJyUA==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "globby": "^11.0.3"
+      },
+      "engines": {
+        "node": "^12.18.3 || >=14"
       }
     },
     "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/types": {
-      "version": "2.0.0-nightly.72",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.0.0-nightly.72.tgz",
-      "integrity": "sha512-NJfVFyUVUjZf3NrFb0CRQk5MPAyr/zpfYZw81eW9JwjFMhBumqW5kN/Qy75UXNznOBhl28q4ZGYQUbucnJxTrw==",
-      "dev": true
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.0.0-rc.0.tgz",
+      "integrity": "sha512-v1/pS/benX/ekED8FC5kcKfUJffuPcvllzuZKaBlV5rsMwlRbMtdWfRfJ+ibdEIqjvJRtflt84p88Oo725SMQA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/cache": "2.0.0-rc.0",
+        "@parcel/diagnostic": "2.0.0-rc.0",
+        "@parcel/fs": "2.0.0-rc.0",
+        "@parcel/package-manager": "2.0.0-rc.0",
+        "@parcel/source-map": "2.0.0-rc.6",
+        "@parcel/workers": "2.0.0-rc.0",
+        "utility-types": "^3.10.0"
+      }
     },
     "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/utils": {
-      "version": "2.0.0-nightly.72",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-nightly.72.tgz",
-      "integrity": "sha512-JaGKf3fArez1WMjzkJrUMHQ/kjRRfRJKOYS00O2d9aUYSlaUA0z744JUl9oTIspnWtqOhNfWEc1IU6mfTCk1dQ==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-rc.0.tgz",
+      "integrity": "sha512-4W5HT3zILVH0c8W1SMu6jPYtjEy7qh2IOSDR2KiUlT1jFF1OOjd4iQFAEYvHP0iBr1mdiSwXEdkEMhm4hR9xYA==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.0",
-        "@parcel/codeframe": "2.0.0-nightly.72+a0d19756",
-        "@parcel/diagnostic": "2.0.0-nightly.72+a0d19756",
-        "@parcel/logger": "2.0.0-nightly.72+a0d19756",
-        "@parcel/markdown-ansi": "2.0.0-nightly.72+a0d19756",
+        "@parcel/codeframe": "2.0.0-rc.0",
+        "@parcel/diagnostic": "2.0.0-rc.0",
+        "@parcel/hash": "2.0.0-rc.0",
+        "@parcel/logger": "2.0.0-rc.0",
+        "@parcel/markdown-ansi": "2.0.0-rc.0",
+        "@parcel/source-map": "2.0.0-rc.6",
         "ansi-html": "^0.0.7",
-        "chalk": "^2.4.2",
+        "chalk": "^4.1.0",
         "clone": "^2.1.1",
-        "fast-glob": "^3.0.4",
+        "fast-glob": "3.1.1",
+        "fastest-levenshtein": "^1.0.8",
         "is-glob": "^4.0.0",
         "is-url": "^1.2.2",
-        "js-levenshtein": "^1.1.6",
         "json5": "^1.0.1",
-        "micromatch": "^4.0.2",
-        "node-forge": "^0.8.1",
+        "lru-cache": "^6.0.0",
+        "micromatch": "^3.0.4",
+        "node-forge": "^0.10.0",
         "nullthrows": "^1.1.1",
-        "resolve": "^1.12.0",
-        "serialize-to-js": "^3.0.1",
-        "terser": "^3.7.3"
+        "open": "^7.0.3"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
-    },
-    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/emphasize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emphasize/-/emphasize-2.1.0.tgz",
-      "integrity": "sha512-wRlO0Qulw2jieQynsS3STzTabIhHCyjTjZraSkchOiT8rdvWZlahJAJ69HRxwGkv2NThmci2MSnDfJ60jB39tw==",
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/@parcel/workers": {
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.0.0-rc.0.tgz",
+      "integrity": "sha512-HYRr8wg+PwRpZJDFpAZ0te6jVJKQlg4QkfH9nV0u9BktBVs/fmRWH/t4qYZz2c4W2zF+xIe8EfZbkafeETH67Q==",
       "dev": true,
       "dependencies": {
-        "chalk": "^2.4.0",
-        "highlight.js": "~9.12.0",
-        "lowlight": "~1.9.0"
+        "@parcel/diagnostic": "2.0.0-rc.0",
+        "@parcel/logger": "2.0.0-rc.0",
+        "@parcel/types": "2.0.0-rc.0",
+        "@parcel/utils": "2.0.0-rc.0",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.0.0-alpha.3.1"
       }
     },
-    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/highlight.js": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
-      "deprecated": "Version no longer supported. Upgrade to @latest",
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@parcel/reporter-bundle-analyzer/node_modules/json5": {
@@ -2188,49 +2538,104 @@
         "json5": "lib/cli.js"
       }
     },
-    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/lowlight": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
-      "integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "dependencies": {
-        "fault": "^1.0.2",
-        "highlight.js": "~9.12.0"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/node-forge": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true,
       "engines": {
-        "node": ">= 4.5.0"
+        "node": ">=4"
       }
     },
-    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/terser": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
-        "commander": "^2.19.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.10"
-      },
-      "bin": {
-        "terser": "bin/uglifyjs"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@parcel/reporter-bundle-analyzer/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/@parcel/reporter-cli": {
@@ -4510,24 +4915,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -7874,15 +8261,6 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "node_modules/js-levenshtein": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8182,6 +8560,35 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+    },
+    "node_modules/lmdb-store": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/lmdb-store/-/lmdb-store-1.6.7.tgz",
+      "integrity": "sha512-q9q7zNhuFWjSD0fDmyB5hiQkOY3UUJ6LPjhs+W/zJdleRLOLPFR6bAh9nERHGkmEA49sZtZRwFPCwPWGM8qdzA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "nan": "^2.14.2",
+        "node-gyp-build": "^4.2.3",
+        "ordered-binary": "^1.0.0",
+        "weak-lru-cache": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "msgpackr": "^1.3.7"
+      }
+    },
+    "node_modules/lmdb-store/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/loader-utils": {
       "version": "1.4.0",
@@ -8564,6 +8971,34 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/msgpackr": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.4.3.tgz",
+      "integrity": "sha512-QxNu1m6L8ZlAZn3bMAkGxCJTs6nLPcBt1j+ku/ksF2leEDAX2aM2srCZCL80HwwkWokzm1et16Oo8MnRkxIN4A==",
+      "dev": true,
+      "optional": true,
+      "optionalDependencies": {
+        "msgpackr-extract": "^1.0.13"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-1.0.13.tgz",
+      "integrity": "sha512-JlQPllMLETiuQ5Vv3IAz+4uOpd1GZPOoCHv9P5ka5P5gkTssm/ejv0WwS4xAfB9B3vDwrExRwuU8v3HRQtJk2Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.14.2",
+        "node-gyp-build": "^4.2.3"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.1.23",
@@ -9086,6 +9521,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ordered-binary": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.1.3.tgz",
+      "integrity": "sha512-tDTls+KllrZKJrqRXUYJtIcWIyoQycP7cVN7kzNNnhHKF2bMKHflcAQK+pF2Eb1iVaQodHxqZQr0yv4HWLGBhQ==",
+      "dev": true
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",
@@ -12013,15 +12454,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/serialize-to-js": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.1.1.tgz",
-      "integrity": "sha512-F+NGU0UHMBO4Q965tjw7rvieNVjlH6Lqi2emq/Lc9LUURYJbiCzmpi4Cy1OOjjVPtxu0c+NE85LU6968Wko5ZA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/serve-handler": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
@@ -13497,6 +13929,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -13585,6 +14026,12 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/weak-lru-cache": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.1.2.tgz",
+      "integrity": "sha512-Bi5ae8Bev3YulgtLTafpmHmvl3vGbanRkv+qqA2AX8c3qj/MUdvSuaHq7ukDYBcMDINIaRPTPEkXSNCqqWivuA==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
@@ -13726,6 +14173,12 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
+      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==",
+      "dev": true
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -14677,6 +15130,16 @@
         "readable-stream": "1 || 2"
       }
     },
+    "@parcel/hash": {
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.0.0-rc.0.tgz",
+      "integrity": "sha512-qbR1evXfjR4t0LhY3z32nrGnPh32vsuafS6rrS4JOJyD7mbOsHUKsT1Vkggh3R5Jv0sMtuRqlYngK59WO/Yzbg==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "xxhash-wasm": "^0.4.1"
+      }
+    },
     "@parcel/logger": {
       "version": "2.0.0-beta.3.1",
       "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-beta.3.1.tgz",
@@ -15104,30 +15567,43 @@
       }
     },
     "@parcel/reporter-bundle-analyzer": {
-      "version": "2.0.0-nightly.1694",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-analyzer/-/reporter-bundle-analyzer-2.0.0-nightly.1694.tgz",
-      "integrity": "sha512-avRxTF1tHXRnoufI4Fguv9Z5PoBpvSG0EyPR9RhHaL7DEGXFDw+Rg9We0z6aaEaQYAfSZ0KnTp9cWXjjvIlkbw==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-analyzer/-/reporter-bundle-analyzer-2.0.0-rc.0.tgz",
+      "integrity": "sha512-22OUWJ4SVlxx/7kqippwGpJ3qsaEiiUlxzYNfI3hfJvi/PPu0urspaPF2X5tIW0G98YeD/O0ytiuFPROUSa6AQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-nightly.72+a0d19756",
-        "@parcel/utils": "2.0.0-nightly.72+a0d19756",
+        "@parcel/plugin": "2.0.0-rc.0",
+        "@parcel/utils": "2.0.0-rc.0",
         "nullthrows": "^1.1.1"
       },
       "dependencies": {
-        "@parcel/codeframe": {
-          "version": "2.0.0-nightly.72",
-          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.0.0-nightly.72.tgz",
-          "integrity": "sha512-qpfzQlJpqlT9KPIVsooigHdLbscO00U+tZ0E0YdjYLd9PsBwAiuYEqh1AqoRPTy8eOu/U0bAakD4yU5n0KkwNw==",
+        "@parcel/cache": {
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.0.0-rc.0.tgz",
+          "integrity": "sha512-XW3evoovrpr661Ts7Pgw6OTQ+TC63yCffd/+e4qvxD+/nmvHLRUnJR66gRX9GzbG7xaEfJvgcENbxx1CHNm3WA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "emphasize": "^2.1.0"
+            "@parcel/logger": "2.0.0-rc.0",
+            "@parcel/utils": "2.0.0-rc.0",
+            "lmdb-store": "^1.5.5"
+          }
+        },
+        "@parcel/codeframe": {
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.0.0-rc.0.tgz",
+          "integrity": "sha512-wJR/5y1xAutpCPTpDSEpSO1d5Tm6GYQZ1kNS9jx+J7KVcwpwB/ypw9mon+4kFoyegkc98YaJpTm3jlL/bBJblg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "emphasize": "^4.2.0",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.0"
           }
         },
         "@parcel/diagnostic": {
-          "version": "2.0.0-nightly.72",
-          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0-nightly.72.tgz",
-          "integrity": "sha512-9Z3rr0sK0iJlYodrLtDuXbh3SFMd9xsf8L1a8MZ5WV1+MskGS/gIIC829EN7l7Vw8hWXqr6OX6lTg0dDCClblg==",
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0-rc.0.tgz",
+          "integrity": "sha512-s8hzLkUcgFqwfuCxHHuqx0zyeDU+GYtz69StWlCECXumHJMS0iaomE4IaKW5fsIMsdgndg7g4/yZc2eMXiHR1Q==",
           "dev": true,
           "requires": {
             "json-source-map": "^0.6.1",
@@ -15135,94 +15611,296 @@
           }
         },
         "@parcel/events": {
-          "version": "2.0.0-nightly.72",
-          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0-nightly.72.tgz",
-          "integrity": "sha512-TQCiFzLEqN74jXRFZ9/FFhO3//POaCbYopi3R9di+3JkbjIqE+lwsuuyGmnZhsQWPaggiZDzF9gIOTWeSzCH+A==",
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0-rc.0.tgz",
+          "integrity": "sha512-k/fqhFXyQQYqo/2Y0pfxz97usoW14+g5hFO1Kfnto3t5l46M8sU65Di6qLHeTEVkO2cWh/alc7N8QxlcXmxO3Q==",
           "dev": true
         },
-        "@parcel/logger": {
-          "version": "2.0.0-nightly.72",
-          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-nightly.72.tgz",
-          "integrity": "sha512-vieHepW22Sj+yqs7yW2b5nbbkv9nxn1ilmeuJyGVXA4hw3FCKRLttZPv/nE6sN3KeXt77pvrrO3kCvhEcnby8A==",
+        "@parcel/fs": {
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.0.0-rc.0.tgz",
+          "integrity": "sha512-vUXkiNiHa6cc9QrV4GGi40ID27aH5a/GNZ8G2EZxnPtC7FXjrI359CAt7qU8rGxOyPVECGNIwBr+e31p+Xg/Lg==",
           "dev": true,
           "requires": {
-            "@parcel/diagnostic": "2.0.0-nightly.72+a0d19756",
-            "@parcel/events": "2.0.0-nightly.72+a0d19756"
+            "@parcel/fs-search": "2.0.0-rc.0",
+            "@parcel/fs-write-stream-atomic": "2.0.0-rc.0",
+            "@parcel/types": "2.0.0-rc.0",
+            "@parcel/utils": "2.0.0-rc.0",
+            "@parcel/watcher": "2.0.0-alpha.10",
+            "@parcel/workers": "2.0.0-rc.0",
+            "graceful-fs": "^4.2.4",
+            "mkdirp": "^0.5.1",
+            "ncp": "^2.0.0",
+            "nullthrows": "^1.1.1",
+            "rimraf": "^3.0.2",
+            "utility-types": "^3.10.0"
+          }
+        },
+        "@parcel/fs-search": {
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.0.0-rc.0.tgz",
+          "integrity": "sha512-x/gdmnxWIhuP6kVUe3u8fiY5JBCmALHNJIPNDGdoVada1CEEHF+DJtQG7LT+LIcPFeAqXT6qx05HrgO94KLaUQ==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.3"
+          }
+        },
+        "@parcel/fs-write-stream-atomic": {
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/fs-write-stream-atomic/-/fs-write-stream-atomic-2.0.0-rc.0.tgz",
+          "integrity": "sha512-KQ9FbE+ee2nzEtZwdVcxup1uWGfyfKj0cDsbxfak+oMubDTb3ycQlyCAnVPKoybvxqpsTG+TKDXObDz8SBCF1A==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "iferr": "^1.0.2",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
+          }
+        },
+        "@parcel/logger": {
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-rc.0.tgz",
+          "integrity": "sha512-gUbEN0iTM0E8Vb0qhLev/AcHyKc3McVWOSZQDC31CQ0DpPY8KPVmDR4tEL+hC0YEl6ekpG2c41F5XpH2mzTawg==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.0.0-rc.0",
+            "@parcel/events": "2.0.0-rc.0"
           }
         },
         "@parcel/markdown-ansi": {
-          "version": "2.0.0-nightly.72",
-          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-nightly.72.tgz",
-          "integrity": "sha512-j0HojLH+e0L8naFHjcDwEOnSzjh9lH32bxkoHZgibg2MYuGssB/X6EQbzf+Lw135i+hTEPnPzYZBhWnofTKogw==",
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-rc.0.tgz",
+          "integrity": "sha512-ipR71hKCpqq9aXaPCordBPETYP/QyrN2t2Ra7tPPCvNful44i0JqWakPeSrDO1HJT1s1GI1lGpIk+ytc/5PCCg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2"
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/package-manager": {
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.0.0-rc.0.tgz",
+          "integrity": "sha512-QA1B7FViEMB0CpEeEV1oCqIDFHDReYWL38NnwWesLiewIAeIZHLCHqN35ClCK84F8NnCUp9uMymDv61rwJlq9A==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.0.0-rc.0",
+            "@parcel/fs": "2.0.0-rc.0",
+            "@parcel/logger": "2.0.0-rc.0",
+            "@parcel/types": "2.0.0-rc.0",
+            "@parcel/utils": "2.0.0-rc.0",
+            "@parcel/workers": "2.0.0-rc.0",
+            "command-exists": "^1.2.6",
+            "cross-spawn": "^6.0.4",
+            "nullthrows": "^1.1.1",
+            "semver": "^5.4.1",
+            "split2": "^3.1.1"
           }
         },
         "@parcel/plugin": {
-          "version": "2.0.0-nightly.72",
-          "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.0.0-nightly.72.tgz",
-          "integrity": "sha512-R1COpRwbinYmOotrE9bpWqeDhdpT6tZT3VBjlqeq/snaQydfC1No4GYHsZYANCg6/U+QJIfRZz12dLDQfL4i4w==",
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.0.0-rc.0.tgz",
+          "integrity": "sha512-dCfnWnkoqsPijEHKhisENDiGBUUCLuZfjPkVGqMcKBpLhv6bnh3ivmXyC9bcJBZJ8BV9Ytltj+ooOyFOMQRJnQ==",
           "dev": true,
           "requires": {
-            "@parcel/types": "2.0.0-nightly.72+a0d19756"
+            "@parcel/types": "2.0.0-rc.0"
+          }
+        },
+        "@parcel/source-map": {
+          "version": "2.0.0-rc.6",
+          "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.0-rc.6.tgz",
+          "integrity": "sha512-qtXLd9dbxWx/ybe1dduAzAGzb7iTSQv3imNZo7pVyEtSaCcphg+rTmY8/Fg3MQqqu7of/2+tEqNAGMz8nOJyUA==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "globby": "^11.0.3"
           }
         },
         "@parcel/types": {
-          "version": "2.0.0-nightly.72",
-          "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.0.0-nightly.72.tgz",
-          "integrity": "sha512-NJfVFyUVUjZf3NrFb0CRQk5MPAyr/zpfYZw81eW9JwjFMhBumqW5kN/Qy75UXNznOBhl28q4ZGYQUbucnJxTrw==",
-          "dev": true
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.0.0-rc.0.tgz",
+          "integrity": "sha512-v1/pS/benX/ekED8FC5kcKfUJffuPcvllzuZKaBlV5rsMwlRbMtdWfRfJ+ibdEIqjvJRtflt84p88Oo725SMQA==",
+          "dev": true,
+          "requires": {
+            "@parcel/cache": "2.0.0-rc.0",
+            "@parcel/diagnostic": "2.0.0-rc.0",
+            "@parcel/fs": "2.0.0-rc.0",
+            "@parcel/package-manager": "2.0.0-rc.0",
+            "@parcel/source-map": "2.0.0-rc.6",
+            "@parcel/workers": "2.0.0-rc.0",
+            "utility-types": "^3.10.0"
+          }
         },
         "@parcel/utils": {
-          "version": "2.0.0-nightly.72",
-          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-nightly.72.tgz",
-          "integrity": "sha512-JaGKf3fArez1WMjzkJrUMHQ/kjRRfRJKOYS00O2d9aUYSlaUA0z744JUl9oTIspnWtqOhNfWEc1IU6mfTCk1dQ==",
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-rc.0.tgz",
+          "integrity": "sha512-4W5HT3zILVH0c8W1SMu6jPYtjEy7qh2IOSDR2KiUlT1jFF1OOjd4iQFAEYvHP0iBr1mdiSwXEdkEMhm4hR9xYA==",
           "dev": true,
           "requires": {
             "@iarna/toml": "^2.2.0",
-            "@parcel/codeframe": "2.0.0-nightly.72+a0d19756",
-            "@parcel/diagnostic": "2.0.0-nightly.72+a0d19756",
-            "@parcel/logger": "2.0.0-nightly.72+a0d19756",
-            "@parcel/markdown-ansi": "2.0.0-nightly.72+a0d19756",
+            "@parcel/codeframe": "2.0.0-rc.0",
+            "@parcel/diagnostic": "2.0.0-rc.0",
+            "@parcel/hash": "2.0.0-rc.0",
+            "@parcel/logger": "2.0.0-rc.0",
+            "@parcel/markdown-ansi": "2.0.0-rc.0",
+            "@parcel/source-map": "2.0.0-rc.6",
             "ansi-html": "^0.0.7",
-            "chalk": "^2.4.2",
+            "chalk": "^4.1.0",
             "clone": "^2.1.1",
-            "fast-glob": "^3.0.4",
+            "fast-glob": "3.1.1",
+            "fastest-levenshtein": "^1.0.8",
             "is-glob": "^4.0.0",
             "is-url": "^1.2.2",
-            "js-levenshtein": "^1.1.6",
             "json5": "^1.0.1",
-            "micromatch": "^4.0.2",
-            "node-forge": "^0.8.1",
+            "lru-cache": "^6.0.0",
+            "micromatch": "^3.0.4",
+            "node-forge": "^0.10.0",
             "nullthrows": "^1.1.1",
-            "resolve": "^1.12.0",
-            "serialize-to-js": "^3.0.1",
-            "terser": "^3.7.3"
+            "open": "^7.0.3"
           }
         },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        },
-        "emphasize": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emphasize/-/emphasize-2.1.0.tgz",
-          "integrity": "sha512-wRlO0Qulw2jieQynsS3STzTabIhHCyjTjZraSkchOiT8rdvWZlahJAJ69HRxwGkv2NThmci2MSnDfJ60jB39tw==",
+        "@parcel/workers": {
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.0.0-rc.0.tgz",
+          "integrity": "sha512-HYRr8wg+PwRpZJDFpAZ0te6jVJKQlg4QkfH9nV0u9BktBVs/fmRWH/t4qYZz2c4W2zF+xIe8EfZbkafeETH67Q==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.0",
-            "highlight.js": "~9.12.0",
-            "lowlight": "~1.9.0"
+            "@parcel/diagnostic": "2.0.0-rc.0",
+            "@parcel/logger": "2.0.0-rc.0",
+            "@parcel/types": "2.0.0-rc.0",
+            "@parcel/utils": "2.0.0-rc.0",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
           }
         },
-        "highlight.js": {
-          "version": "9.12.0",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-          "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "dev": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
         },
         "json5": {
           "version": "1.0.1",
@@ -15233,37 +15911,80 @@
             "minimist": "^1.2.0"
           }
         },
-        "lowlight": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
-          "integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "fault": "^1.0.2",
-            "highlight.js": "~9.12.0"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         },
-        "node-forge": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-          "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
-        "terser": {
-          "version": "3.17.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-          "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
-            "commander": "^2.19.0",
-            "source-map": "~0.6.1",
-            "source-map-support": "~0.5.10"
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -16980,15 +17701,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {
@@ -19567,12 +20279,6 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "js-levenshtein": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -19834,6 +20540,28 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+    },
+    "lmdb-store": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/lmdb-store/-/lmdb-store-1.6.7.tgz",
+      "integrity": "sha512-q9q7zNhuFWjSD0fDmyB5hiQkOY3UUJ6LPjhs+W/zJdleRLOLPFR6bAh9nERHGkmEA49sZtZRwFPCwPWGM8qdzA==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "msgpackr": "^1.3.7",
+        "nan": "^2.14.2",
+        "node-gyp-build": "^4.2.3",
+        "ordered-binary": "^1.0.0",
+        "weak-lru-cache": "^1.0.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
+      }
     },
     "loader-utils": {
       "version": "1.4.0",
@@ -20142,6 +20870,33 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "msgpackr": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.4.3.tgz",
+      "integrity": "sha512-QxNu1m6L8ZlAZn3bMAkGxCJTs6nLPcBt1j+ku/ksF2leEDAX2aM2srCZCL80HwwkWokzm1et16Oo8MnRkxIN4A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "msgpackr-extract": "^1.0.13"
+      }
+    },
+    "msgpackr-extract": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-1.0.13.tgz",
+      "integrity": "sha512-JlQPllMLETiuQ5Vv3IAz+4uOpd1GZPOoCHv9P5ka5P5gkTssm/ejv0WwS4xAfB9B3vDwrExRwuU8v3HRQtJk2Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.2",
+        "node-gyp-build": "^4.2.3"
+      }
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true
     },
     "nanoid": {
       "version": "3.1.23",
@@ -20530,6 +21285,12 @@
           }
         }
       }
+    },
+    "ordered-binary": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.1.3.tgz",
+      "integrity": "sha512-tDTls+KllrZKJrqRXUYJtIcWIyoQycP7cVN7kzNNnhHKF2bMKHflcAQK+pF2Eb1iVaQodHxqZQr0yv4HWLGBhQ==",
+      "dev": true
     },
     "os-browserify": {
       "version": "0.3.0",
@@ -22771,12 +23532,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
-    "serialize-to-js": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.1.1.tgz",
-      "integrity": "sha512-F+NGU0UHMBO4Q965tjw7rvieNVjlH6Lqi2emq/Lc9LUURYJbiCzmpi4Cy1OOjjVPtxu0c+NE85LU6968Wko5ZA==",
-      "dev": true
-    },
     "serve-handler": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
@@ -23980,6 +24735,12 @@
         "object.getownpropertydescriptors": "^2.1.0"
       }
     },
+    "utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
+      "dev": true
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -24054,6 +24815,12 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "weak-lru-cache": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.1.2.tgz",
+      "integrity": "sha512-Bi5ae8Bev3YulgtLTafpmHmvl3vGbanRkv+qqA2AX8c3qj/MUdvSuaHq7ukDYBcMDINIaRPTPEkXSNCqqWivuA==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "4.0.2",
@@ -24159,6 +24926,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    },
+    "xxhash-wasm": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
+      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "start": "parcel serve index.html",
     "build": "parcel build index.html --detailed-report 20",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "analyzer-build": "cross-env PARCEL_BUNDLE_ANALYZER=1 parcel build index.html --reporter @parcel/reporter-bundle-analyzer",
+    "analyzer":  "npm run -s analyzer-build && parcel serve parcel-bundle-reports/default.html --open"
   },
   "dependencies": {
     "@emotion/react": "^11.4.0",
@@ -31,8 +33,10 @@
     "@babel/plugin-transform-runtime": "^7.14.5",
     "@babel/preset-react": "^7.14.5",
     "@babel/runtime": "^7.14.8",
+    "@parcel/reporter-bundle-analyzer": "^2.0.0-beta.3.1",
     "@parcel/transformer-svg-react": "2.0.0-beta.3.1",
     "@welldone-software/why-did-you-render": "^6.2.0",
+    "cross-env": "^7.0.3",
     "eslint": "^7.32.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.24.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "start": "parcel serve index.html",
     "build": "parcel build index.html --detailed-report 20",
     "format": "prettier --write .",
-    "analyzer-build": "cross-env PARCEL_BUNDLE_ANALYZER=1 parcel build index.html --reporter @parcel/reporter-bundle-analyzer",
-    "analyzer":  "npm run -s analyzer-build && parcel serve parcel-bundle-reports/default.html --open"
+    "analyzer-build": "parcel build index.html --reporter @parcel/reporter-bundle-analyzer",
+    "analyzer": "npm run -s analyzer-build && parcel serve parcel-bundle-reports/default.html --open"
   },
   "dependencies": {
     "@emotion/react": "^11.4.0",
@@ -36,7 +36,6 @@
     "@parcel/reporter-bundle-analyzer": "^2.0.0-beta.3.1",
     "@parcel/transformer-svg-react": "2.0.0-beta.3.1",
     "@welldone-software/why-did-you-render": "^6.2.0",
-    "cross-env": "^7.0.3",
     "eslint": "^7.32.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.24.0",


### PR DESCRIPTION
Adds the ability to find out the makeup of the application to find how large certain packages are, what is used within them, and if it can be improved.
This uses the built-in parcel build bundle [analyzer ](https://v2.parceljs.org/features/production/#bundle-analyzer)
It adds [cross-env](https://www.npmjs.com/package/cross-env) because some people might be on Linux, some on Windows, this helps easily deal with setting the env key `PARCEL_BUNDLE_ANALYZER` which I found [here](https://github.com/gregtillbrook/parcel-plugin-bundle-visualiser/issues/30#issuecomment-856920195)
It is a purely dev thing that doesn't affect the main build itself.
It pipes it through `parcel serve` for ease of opening in a browser window.