### PR TITLE
Remove discriminators from displayed usernames

### DIFF
--- a/scripts/components/Drawfest/DrawfestSubmissions.js
+++ b/scripts/components/Drawfest/DrawfestSubmissions.js
@@ -74,7 +74,7 @@ function DrawfestSubmissionsBody({ submissions, promptData }) {
               css={{ width: 64, height: 64 }}
             />
           </TableCell>
-          <TableCell>{`${row.username}#${row.discriminator}`}</TableCell>
+          <TableCell>{row.username}</TableCell>
           <ApprovedCell
             approvedSubmissions={row.submissions}
             promptData={promptData}
@@ -89,7 +89,6 @@ DrawfestSubmissionsBody.propTypes = {
   submissions: PropTypes.arrayOf(
     PropTypes.shape({
       username: PropTypes.string,
-      discriminator: PropTypes.string,
       approved_submissions: PropTypes.arrayOf(PropTypes.number),
       id: PropTypes.string,
       avatar: PropTypes.string,


### PR DESCRIPTION
Makes the Drawfest page look a little bit less silly, since discriminators no longer exist for users:

<img width="214" height="97" alt="image" src="https://github.com/user-attachments/assets/bd23d2e8-8af7-4768-a7f1-f3e1fe9da54d" />
<img width="202" height="97" alt="image" src="https://github.com/user-attachments/assets/5ba59383-84a0-4f05-8906-d1073b091f48" />
